### PR TITLE
Add Ruby-style method to GObject objects

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -1,8 +1,13 @@
+require 'ffi-gobject/ruby_style'
+
 module GObject
   load_class :Object
 
   # Overrides for GObject, GObject's generic base class.
   class Object
+
+    include RubyStyle
+
     _setup_method "new"
     _setup_instance_method "get_property"
     _setup_instance_method "set_property"

--- a/lib/ffi-gobject/ruby_style.rb
+++ b/lib/ffi-gobject/ruby_style.rb
@@ -1,0 +1,21 @@
+module GObject
+
+  module RubyStyle
+
+    def method_missing(method, *args)
+      if respond_to?("get_#{method}")
+        return send("get_#{method}", *args)
+      end
+      if method.to_s =~ /(.*)=$/ && respond_to?("set_#{$1}")
+        return send("set_#{$1}", *args)
+      end
+      super
+    end
+
+    def signal_connect(event, &block)
+      GObject.signal_connect(self, event, &block)
+    end
+
+  end
+
+end

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -8,5 +8,9 @@ describe GObject::Object do
       assert_equal 1,
         GObject::Object.instance_method("get_property").arity
     end
+
+    it 'includes GObject::RubyStyle' do
+      assert GObject::Object.included_modules.include?(GObject::RubyStyle)
+    end
   end
 end

--- a/test/ffi-gobject/ruby_style.rb
+++ b/test/ffi-gobject/ruby_style.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../gir_ffi_test_helper.rb', File.dirname(__FILE__))
+
+require 'ffi-gobject/ruby_style'
+
+describe GObject::RubyStyle do
+  class RubyStyleTest
+    include GObject::RubyStyle
+    def get_x
+      @x
+    end
+    def set_x(val)
+      @x = val
+    end
+  end
+
+  subject { RubyStyleTest.new }
+
+  it 'reads x by calling get_x' do
+    subject.set_x(1)
+    assert_equal 1, subject.x
+  end
+
+  it 'writes x by calling set_x' do
+    subject.x = 2
+    assert_equal 2, subject.x
+  end
+
+  it 'delegates signal_connect to GObject' do
+    block = lambda {}
+    mock(GObject).signal_connect(subject, 'some-event')
+    subject.signal_connect('some-event') do
+      nothing
+    end
+
+    RR.verify
+  end
+
+end
+


### PR DESCRIPTION
Hi,

I thought it would be nice  adding these convenience methods to GObject::Object to make the API look more like we are used in Ruby. What do you think?

All tests pass (except one that was already failing before I implemented this)
