### PR TITLE
handle :interface type in #cast_signal_argument

### DIFF
--- a/lib/ffi-gobject/helper.rb
+++ b/lib/ffi-gobject/helper.rb
@@ -85,6 +85,8 @@ module GObject
         case iface.info_type
         when :enum, :flags
           kls[arg]
+        when :interface
+          arg.to_object
         else
           kls.wrap(arg)
         end


### PR DESCRIPTION
Another Problem I had, related to #27, was that the "match-selected" callback for completions threw this error when called:

<pre>
[...]/gir_ffi-0.3.1/lib/ffi-gobject/helper.rb:89:in `cast_signal_argument': undefined method `wrap' for Gtk::TreeModel:Module (NoMethodError)
        from [...]/gir_ffi-0.3.1/lib/ffi-gobject/helper.rb:74:in `block in cast_back_signal_arguments'
        from [...]/gir_ffi-0.3.1/lib/ffi-gobject/helper.rb:73:in `map'
        from [...]/gir_ffi-0.3.1/lib/ffi-gobject/helper.rb:73:in `cast_back_signal_arguments'
        from [...]/gir_ffi-0.3.1/lib/ffi-gobject/helper.rb:16:in `block in signal_callback_args'
        from (eval):2:in `call'
        from (eval):2:in `gtk_main'
        from (eval):2:in `main'
        from [...]/gir_ffi-0.3.1/lib/gir_ffi/module_base.rb:6:in `method_missing'
        from test.rb:49:in `<main>'
</pre>


I'm not sure, since the arg.to_object is a ListStore and not a TreeModel, but this seems to fix the Problem :P
Unfortunately, I also have no idea how to write a test for this.. Just thought I'd let you know.
