### PR TITLE
remove rc<100 check from gobject

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -14,7 +14,7 @@ module GObject
     def self.make_finalizer ptr, name
       proc {
         rc = GObject::Object::Struct.new(ptr)[:ref_count]
-        if rc == 0 || rc > 100
+        if rc == 0 
           warn "not unreffing #{name}:#{ptr} (#{rc})"
         else
           GObject::Lib.g_object_unref ptr


### PR DESCRIPTION
I can get ref counts > 100 :-( remove this check

perhaps 1,000,000 if you need a sanity test?