### PR TITLE
Avoid duplicate gem installs on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
 before_install:
   - rvm use @global
   - gem uninstall bundler -x
+  - rvm use @default
   - gem install bundler --version=1.13.7
   - bundler --version
   - sudo apt-get -qq update


### PR DESCRIPTION
This should avoid getting method redefined warnings when loading rspec-mocks.