### PR TITLE
Handle incompatible changes in GLib 2.54 and GObjectIntrospection 1.54

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -8,6 +8,7 @@ module GObject
   # Overrides for GObject, GObject's generic base class.
   class Object
     setup_method 'new'
+    setup_method 'newv'
 
     def initialize_with_automatic_gtype(properties = {})
       gparameters = properties.map do |name, value|

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -8,18 +8,34 @@ module GObject
   # Overrides for GObject, GObject's generic base class.
   class Object
     setup_method 'new'
-    setup_method 'newv'
+    if !GLib.check_version(2, 54, 0)
+      setup_method 'newv'
 
-    def initialize_with_automatic_gtype(properties = {})
-      gparameters = properties.map do |name, value|
-        name = name.to_s
-        property_param_spec(name)
-        GObject::Parameter.new.tap do |gparam|
-          gparam.name = name
-          gparam.value = value
+      def initialize_with_automatic_gtype(properties = {})
+        names = []
+        values = []
+        properties.each do |name, value|
+          name = name.to_s
+          gvalue = gvalue_for_property(name)
+          gvalue.set_value value
+
+          names << name
+          values << gvalue
         end
+        initialize_without_automatic_gtype(self.class.gtype, names, values)
       end
-      initialize_without_automatic_gtype(self.class.gtype, gparameters)
+    else
+      def initialize_with_automatic_gtype(properties = {})
+        gparameters = properties.map do |name, value|
+          name = name.to_s
+          property_param_spec(name)
+          GObject::Parameter.new.tap do |gparam|
+            gparam.name = name
+            gparam.value = value
+          end
+        end
+        initialize_without_automatic_gtype(self.class.gtype, gparameters)
+      end
     end
 
     alias_method :initialize_without_automatic_gtype, :initialize

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -2827,7 +2827,15 @@ describe Regress do
   end
 
   it 'has a working function #annotation_transfer_floating' do
-    Regress.annotation_transfer_floating.must_be_nil
+    Regress.setup_method :annotation_transfer_floating
+    method = Regress.method :annotation_transfer_floating
+    # NOTE: The arity of this method was changed in GObjectIntrospection 1.53.2
+    if method.arity == 1
+      object = GObject::Object.new
+      Regress.annotation_transfer_floating(object).must_be_nil
+    else
+      Regress.annotation_transfer_floating.must_be_nil
+    end
   end
 
   it 'has a working function #annotation_versioned' do


### PR DESCRIPTION
* `g_object_newv` was replaced by `g_object_new_with_parameters`. Handle both cases for GObject::Object initialization.
* Provide `newv` in any case for user defined objects.
* The arity of a test method was changed.