### PR TITLE
Make simplecov a regular development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,4 @@ gemspec
 
 if ENV['CI']
   gem 'coveralls', group: :development if ENV['TRAVIS_RUBY_VERSION'] == '2.4'
-else
-  gem 'simplecov', '~> 0.16.1', group: :local_development, platform: :mri
 end

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', ['~> 5.5'])
   s.add_development_dependency('rake', ['~> 12.0'])
   s.add_development_dependency('rspec-mocks', ['~> 3.5'])
+  s.add_development_dependency('simplecov', ['~> 0.16.1'])
 
   s.require_paths = ['lib']
 end

--- a/test/base_test_helper.rb
+++ b/test/base_test_helper.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-begin
-  require 'simplecov'
-  SimpleCov.start do
-    track_files 'lib/**/*.rb'
-    add_filter '/test/'
-  end
+require 'simplecov'
+SimpleCov.start do
+  track_files 'lib/**/*.rb'
+  add_filter '/test/'
+end
 
-  if ENV['CI']
+if ENV['CI']
+  begin
     require 'coveralls'
     Coveralls.wear!
+  rescue LoadError
   end
-rescue LoadError
 end
 
 require 'minitest/autorun'

--- a/test/base_test_helper.rb
+++ b/test/base_test_helper.rb
@@ -11,6 +11,7 @@ if ENV['CI']
     require 'coveralls'
     Coveralls.wear!
   rescue LoadError
+    nil
   end
 end
 


### PR DESCRIPTION
This ensures simplecov is always available so it doesn't have to hide in a
rescue block.