### PR TITLE
Add compatibility with glib 2.58.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source 'https://rubygems.org'
 # The gem's dependencies are specified in gir_ffi.gemspec
 gemspec
 
+gem 'pry', '~> 0.11.0'
+
 if ENV['CI']
   gem 'coveralls', group: :development if ENV['TRAVIS_RUBY_VERSION'] == '2.4'
 end

--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -87,6 +87,7 @@ module GObject
     attach_function :g_object_ref_sink, [:pointer], :pointer
     attach_function :g_object_ref, [:pointer], :pointer
     attach_function :g_object_unref, [:pointer], :pointer
+    attach_function :g_object_new, [:size_t, :pointer], :pointer
 
     attach_function :g_value_copy, [:pointer, :pointer], :void
     attach_function :g_value_init, [:pointer, :size_t], :pointer

--- a/lib/ffi-gobject/closure.rb
+++ b/lib/ffi-gobject/closure.rb
@@ -7,8 +7,8 @@ module GObject
   #
   # To create Closure objects wrapping Ruby code, use {RubyClosure}.
   class Closure
-    setup_method :new_simple
-    setup_instance_method :invoke
+    setup_method! :new_simple
+    setup_instance_method! :invoke
 
     # @override
     #

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -7,7 +7,6 @@ GObject.load_class :Object
 module GObject
   # Overrides for GObject, GObject's generic base class.
   class Object
-    setup_method 'new'
     if !GLib.check_version(2, 54, 0)
       # Starting with GLib 2.54.0, use g_object_new_with_properties, which
       # takes an array of names and an array of values.
@@ -25,6 +24,8 @@ module GObject
         initialize_without_automatic_gtype(self.class.gtype, names, values)
       end
     else
+      setup_method! 'new'
+
       # Before GLib 2.54.0, use g_object_newv, which takes an array of GParameter.
       def initialize_with_automatic_gtype(properties = {})
         gparameters = properties.map do |name, value|

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -8,9 +8,19 @@ module GObject
   # Overrides for GObject, GObject's generic base class.
   class Object
     if !GLib.check_version(2, 54, 0)
+      GObject::Lib.attach_function(:g_object_new_with_properties,
+                                   [:size_t, :uint32, :pointer, :pointer],
+                                   :pointer)
+
+      def self.new(*args, &block)
+        obj = allocate
+        obj.__send__ :initialize, *args, &block
+        obj
+      end
+
       # Starting with GLib 2.54.0, use g_object_new_with_properties, which
       # takes an array of names and an array of values.
-      def initialize_with_automatic_gtype(properties = {})
+      def initialize(properties = {})
         names = []
         values = []
         properties.each do |name, value|
@@ -21,7 +31,16 @@ module GObject
           names << name
           values << gvalue
         end
-        initialize_without_automatic_gtype(self.class.gtype, names, values)
+
+        n_properties = names.length
+        names_arr = GirFFI::SizedArray.from(:utf8, -1, names)
+        values_arr = GirFFI::SizedArray.from(GObject::Value, -1, values)
+
+        ptr = GObject::Lib.g_object_new_with_properties(self.class.gtype,
+                                                        n_properties,
+                                                        names_arr,
+                                                        values_arr)
+        store_pointer ptr
       end
     else
       setup_method! 'new'
@@ -38,10 +57,11 @@ module GObject
         end
         initialize_without_automatic_gtype(self.class.gtype, gparameters)
       end
+
+      alias initialize_without_automatic_gtype initialize
+      alias initialize initialize_with_automatic_gtype
     end
 
-    alias initialize_without_automatic_gtype initialize
-    alias initialize initialize_with_automatic_gtype
     alias base_initialize initialize
 
     private :base_initialize

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -11,6 +11,8 @@ module GObject
     if !GLib.check_version(2, 54, 0)
       setup_method 'newv'
 
+      # Starting with GLib 2.54.0, use g_object_new_with_properties, which
+      # takes an array of names and an array of values.
       def initialize_with_automatic_gtype(properties = {})
         names = []
         values = []
@@ -25,6 +27,7 @@ module GObject
         initialize_without_automatic_gtype(self.class.gtype, names, values)
       end
     else
+      # Before GLib 2.54.0, use g_object_newv, which takes an array of GParameter.
       def initialize_with_automatic_gtype(properties = {})
         gparameters = properties.map do |name, value|
           name = name.to_s

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -9,8 +9,6 @@ module GObject
   class Object
     setup_method 'new'
     if !GLib.check_version(2, 54, 0)
-      setup_method 'newv'
-
       # Starting with GLib 2.54.0, use g_object_new_with_properties, which
       # takes an array of names and an array of values.
       def initialize_with_automatic_gtype(properties = {})

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -255,7 +255,7 @@ module GirFFI
       def setup_constructor
         code = <<-CODE
         def initialize
-          ptr = GObject::Lib.g_object_newv #{@gtype}, 0, nil
+          ptr = GObject::Lib.g_object_new #{@gtype}, nil
           store_pointer(ptr)
         end
         CODE

--- a/lib/gir_ffi/class_base.rb
+++ b/lib/gir_ffi/class_base.rb
@@ -60,6 +60,14 @@ module GirFFI
       gir_ffi_builder.setup_instance_method name
     end
 
+    def self.setup_method!(name)
+      setup_method name or raise "Unknown method #{name}"
+    end
+
+    def self.setup_instance_method!(name)
+      setup_instance_method name or raise "Unknown method #{name}"
+    end
+
     # Wrap the passed pointer in an instance of the current class, or a
     # descendant type if applicable.
     def self.wrap(ptr)

--- a/lib/gir_ffi/module_base.rb
+++ b/lib/gir_ffi/module_base.rb
@@ -28,5 +28,9 @@ module GirFFI
     def setup_method(name)
       gir_ffi_builder.setup_method name
     end
+
+    def setup_method!(name)
+      setup_method name or raise "Unknown method #{name}"
+    end
   end
 end

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -158,7 +158,7 @@ describe GirFFI::Builder do
     end
 
     it 'defines ffi callback types :Callback and :ClosureNotify' do
-      Regress.setup_method 'test_callback_destroy_notify'
+      Regress.setup_method! 'test_callback_destroy_notify'
       tcud = Regress::Lib.find_type :TestCallbackUserData
       dn = GLib::Lib.find_type :DestroyNotify
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -2826,7 +2826,7 @@ describe Regress do
   end
 
   it 'has a working function #annotation_transfer_floating' do
-    Regress.setup_method :annotation_transfer_floating
+    Regress.setup_method! :annotation_transfer_floating
     method = Regress.method :annotation_transfer_floating
     # NOTE: The arity of this method was changed in GObjectIntrospection 1.53.2
     if method.arity == 1


### PR DESCRIPTION
Makes GirFFI work with GLib 2.58/GIRepository 1.58, which make the GObject constructor functions non-introspectable.