### PR TITLE
Unify initializers for regular and user-defined classes

### DIFF
--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -90,7 +90,6 @@ module GObject
     attach_function :g_object_ref_sink, [:pointer], :pointer
     attach_function :g_object_ref, [:pointer], :pointer
     attach_function :g_object_unref, [:pointer], :pointer
-    attach_function :g_object_new, [:size_t, :pointer], :pointer
 
     attach_function :g_value_copy, [:pointer, :pointer], :void
     attach_function :g_value_init, [:pointer, :size_t], :pointer

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -71,7 +71,7 @@ module GirFFI
         setup_property_accessors
         setup_vfunc_invokers
         setup_interfaces
-        provide_initializer
+        setup_initializer
       end
 
       # FIXME: Private method only used in subclass
@@ -129,7 +129,7 @@ module GirFFI
         DEF
       end
 
-      def provide_initializer
+      def setup_initializer
         return if info.find_method 'new'
 
         if info.abstract?

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -16,7 +16,7 @@ module GirFFI
         register_type
         setup_constants
         setup_property_accessors
-        setup_constructor
+        setup_initializer
         TypeBuilder::CACHE[@gtype] = klass
       end
 
@@ -250,15 +250,6 @@ module GirFFI
 
       def method_introspection_data(_method)
         nil
-      end
-
-      def setup_constructor
-        klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
-          def initialize
-            ptr = GObject::Lib.g_object_new #{@gtype}, nil
-            store_pointer(ptr)
-          end
-        CODE
       end
     end
   end

--- a/lib/gir_ffi/user_defined_object_info.rb
+++ b/lib/gir_ffi/user_defined_object_info.rb
@@ -58,6 +58,10 @@ module GirFFI
       nil
     end
 
+    def abstract?
+      false
+    end
+
     attr_writer :g_name
 
     def g_name


### PR DESCRIPTION
This removes the need to manually attach :g_object_new.