### PR TITLE
Simplify field accessors

### DIFF
--- a/lib/gir_ffi/boolean.rb
+++ b/lib/gir_ffi/boolean.rb
@@ -23,8 +23,8 @@ module GirFFI
       FFI.type_size FFI::Type::INT
     end
 
-    def self.copy_value_to_pointer(value, pointer)
-      pointer.put_int 0, to_native(value, nil)
+    def self.copy_value_to_pointer(value, pointer, offset = 0)
+      pointer.put_int offset, to_native(value, nil)
     end
 
     def self.get_value_from_pointer(pointer, offset)

--- a/lib/gir_ffi/builders/field_builder.rb
+++ b/lib/gir_ffi/builders/field_builder.rb
@@ -26,7 +26,7 @@ module GirFFI
 
         def pre_conversion
           [
-            "#{field_ptr} = @struct.to_ptr + #{field_offset}",
+            "#{field_ptr} = @struct.to_ptr",
             "#{bare_value} = #{pointer_to_value_conversion}"
           ]
         end
@@ -58,7 +58,7 @@ module GirFFI
         private
 
         def pointer_to_value_conversion
-          PointerValueConvertor.new(field_type_tag).pointer_to_value(field_ptr)
+          PointerValueConvertor.new(field_type_tag).pointer_to_value(field_ptr, field_offset)
         end
 
         def field_offset

--- a/lib/gir_ffi/builders/field_builder.rb
+++ b/lib/gir_ffi/builders/field_builder.rb
@@ -271,7 +271,7 @@ module GirFFI
 
         <<-CODE.reset_indentation
         def #{info.name}= #{builder.method_argument_name}
-          #{field_ptr} = @struct.to_ptr + #{info.offset}
+          #{field_ptr} = @struct.to_ptr
           #{builder.pre_conversion.join("\n          ")}
           #{value_storage(field_ptr, builder)}
         end
@@ -282,7 +282,7 @@ module GirFFI
 
       def value_storage(typed_ptr, builder)
         PointerValueConvertor.new(field_type_tag).
-          value_to_pointer(typed_ptr, builder.call_argument_name)
+          value_to_pointer(typed_ptr, builder.call_argument_name, info.offset)
       end
 
       def field_type_tag

--- a/lib/gir_ffi/builders/pointer_value_convertor.rb
+++ b/lib/gir_ffi/builders/pointer_value_convertor.rb
@@ -18,12 +18,14 @@ module GirFFI
         end
       end
 
-      def value_to_pointer(ptr_exp, value_exp)
+      def value_to_pointer(ptr_exp, value_exp, offset = 0)
         case ffi_type_spec
         when Module
-          "#{ffi_type_spec}.copy_value_to_pointer(#{value_exp}, #{ptr_exp})"
+          args = [value_exp, ptr_exp]
+          args << offset unless offset == 0
+          "#{ffi_type_spec}.copy_value_to_pointer(#{args.join(', ')})"
         when Symbol
-          "#{ptr_exp}.put_#{ffi_type_spec} 0, #{value_exp}"
+          "#{ptr_exp}.put_#{ffi_type_spec} #{offset}, #{value_exp}"
         end
       end
 

--- a/lib/gir_ffi/builders/pointer_value_convertor.rb
+++ b/lib/gir_ffi/builders/pointer_value_convertor.rb
@@ -9,12 +9,12 @@ module GirFFI
         @type_spec = type_spec
       end
 
-      def pointer_to_value(ptr_exp)
+      def pointer_to_value(ptr_exp, offset = 0)
         case ffi_type_spec
         when Module
-          "#{ffi_type_spec}.get_value_from_pointer(#{ptr_exp}, 0)"
+          "#{ffi_type_spec}.get_value_from_pointer(#{ptr_exp}, #{offset})"
         when Symbol
-          "#{ptr_exp}.get_#{ffi_type_spec}(0)"
+          "#{ptr_exp}.get_#{ffi_type_spec}(#{offset})"
         end
       end
 

--- a/lib/gir_ffi/callback_base.rb
+++ b/lib/gir_ffi/callback_base.rb
@@ -81,8 +81,8 @@ module GirFFI
       to_native.to_ptr
     end
 
-    def self.copy_value_to_pointer(value, pointer)
-      pointer.put_pointer 0, to_native(value, nil)
+    def self.copy_value_to_pointer(value, pointer, offset = 0)
+      pointer.put_pointer offset, to_native(value, nil)
     end
 
     def self.get_value_from_pointer(pointer, offset)

--- a/lib/gir_ffi/enum_like_base.rb
+++ b/lib/gir_ffi/enum_like_base.rb
@@ -22,8 +22,8 @@ module GirFFI
       native_type.size
     end
 
-    def copy_value_to_pointer(value, pointer)
-      pointer.put_int32 0, to_native(value, nil)
+    def copy_value_to_pointer(value, pointer, offset = 0)
+      pointer.put_int32 offset, to_native(value, nil)
     end
 
     def get_value_from_pointer(pointer, offset)

--- a/lib/gir_ffi/sized_array.rb
+++ b/lib/gir_ffi/sized_array.rb
@@ -39,9 +39,9 @@ module GirFFI
       pointer + offset
     end
 
-    def self.copy_value_to_pointer(value, pointer)
+    def self.copy_value_to_pointer(value, pointer, offset = 0)
       size = value.size_in_bytes
-      pointer.put_bytes(0, value.to_ptr.read_bytes(size))
+      pointer.put_bytes(offset, value.to_ptr.read_bytes(size))
     end
 
     def self.wrap(element_type, size, pointer)

--- a/test/gir_ffi/builders/field_builder_test.rb
+++ b/test/gir_ffi/builders/field_builder_test.rb
@@ -11,8 +11,8 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right getter method' do
       expected = <<-CODE.reset_indentation
         def some_int8
-          _v1 = @struct.to_ptr + #{field_info.offset}
-          _v2 = _v1.get_int8(0)
+          _v1 = @struct.to_ptr
+          _v2 = _v1.get_int8(#{field_info.offset})
           _v2
         end
       CODE
@@ -36,8 +36,8 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right getter method' do
       expected = <<-CODE.reset_indentation
         def nested_a
-          _v1 = @struct.to_ptr + #{field_info.offset}
-          _v2 = Regress::TestSimpleBoxedA.get_value_from_pointer(_v1, 0)
+          _v1 = @struct.to_ptr
+          _v2 = Regress::TestSimpleBoxedA.get_value_from_pointer(_v1, #{field_info.offset})
           _v3 = Regress::TestSimpleBoxedA.wrap(_v2)
           _v3
         end
@@ -62,8 +62,8 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right getter method' do
       expected = <<-CODE.reset_indentation
         def some_enum
-          _v1 = @struct.to_ptr + #{field_info.offset}
-          _v2 = Regress::TestEnum.get_value_from_pointer(_v1, 0)
+          _v1 = @struct.to_ptr
+          _v2 = Regress::TestEnum.get_value_from_pointer(_v1, #{field_info.offset})
           _v2
         end
       CODE
@@ -76,8 +76,8 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right getter method' do
       expected = <<-CODE.reset_indentation
         def some_union
-          _v1 = @struct.to_ptr + #{field_info.offset}
-          _v2 = GirFFI::SizedArray.get_value_from_pointer(_v1, 0)
+          _v1 = @struct.to_ptr
+          _v2 = GirFFI::SizedArray.get_value_from_pointer(_v1, #{field_info.offset})
           _v3 = GirFFI::SizedArray.wrap(Regress::TestStructE__some_union__union, 2, _v2)
           _v3
         end
@@ -120,10 +120,10 @@ describe GirFFI::Builders::FieldBuilder do
       skip if field_info.field_type.array_length < 0
       expected = <<-CODE.reset_indentation
         def param_types
-          _v1 = @struct.to_ptr + #{n_params_field_info.offset}
-          _v2 = _v1.get_uint32(0)
-          _v3 = @struct.to_ptr + #{field_info.offset}
-          _v4 = _v3.get_pointer(0)
+          _v1 = @struct.to_ptr
+          _v2 = _v1.get_uint32(#{n_params_field_info.offset})
+          _v3 = @struct.to_ptr
+          _v4 = _v3.get_pointer(#{field_info.offset})
           _v5 = GirFFI::SizedArray.wrap(:GType, _v2, _v4)
           _v5
         end

--- a/test/gir_ffi/builders/field_builder_test.rb
+++ b/test/gir_ffi/builders/field_builder_test.rb
@@ -22,9 +22,9 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right setter method' do
       expected = <<-CODE.reset_indentation
         def some_int8= value
-          _v1 = @struct.to_ptr + #{field_info.offset}
+          _v1 = @struct.to_ptr
           _v2 = value
-          _v1.put_int8 0, _v2
+          _v1.put_int8 #{field_info.offset}, _v2
         end
       CODE
       instance.setter_def.must_equal expected
@@ -48,9 +48,9 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right setter method' do
       expected = <<-CODE.reset_indentation
         def nested_a= value
-          _v1 = @struct.to_ptr + #{field_info.offset}
+          _v1 = @struct.to_ptr
           _v2 = Regress::TestSimpleBoxedA.copy_from(value)
-          Regress::TestSimpleBoxedA.copy_value_to_pointer(_v2, _v1)
+          Regress::TestSimpleBoxedA.copy_value_to_pointer(_v2, _v1, #{field_info.offset})
         end
       CODE
       instance.setter_def.must_equal expected
@@ -88,10 +88,10 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right setter method' do
       expected = <<-CODE.reset_indentation
         def some_union= value
-          _v1 = @struct.to_ptr + #{field_info.offset}
+          _v1 = @struct.to_ptr
           GirFFI::ArgHelper.check_fixed_array_size 2, value, \"value\"
           _v2 = GirFFI::SizedArray.copy_from(Regress::TestStructE__some_union__union, 2, value)
-          GirFFI::SizedArray.copy_value_to_pointer(_v2, _v1)
+          GirFFI::SizedArray.copy_value_to_pointer(_v2, _v1, #{field_info.offset})
         end
       CODE
       instance.setter_def.must_equal expected
@@ -103,9 +103,9 @@ describe GirFFI::Builders::FieldBuilder do
     it 'creates the right setter method' do
       expected = <<-CODE.reset_indentation
         def class_init= value
-          _v1 = @struct.to_ptr + #{field_info.offset}
+          _v1 = @struct.to_ptr
           _v2 = GObject::ClassInitFunc.from(value)
-          GObject::ClassInitFunc.copy_value_to_pointer(_v2, _v1)
+          GObject::ClassInitFunc.copy_value_to_pointer(_v2, _v1, #{field_info.offset})
         end
       CODE
       instance.setter_def.must_equal expected


### PR DESCRIPTION
It makes no sense to calculate the field pointers by hand when the pointer methods include an offset parameter.