### PR TITLE
Remove Object field accessors

### DIFF
--- a/lib/ffi-gobject/param_spec.rb
+++ b/lib/ffi-gobject/param_spec.rb
@@ -5,6 +5,9 @@ GObject.load_class :ParamSpec
 module GObject
   # Overrides for GParamSpec, GObject's base class for parameter specifications.
   class ParamSpec
+    VALUE_TYPE_OFFSET = Struct.offset_of :value_type
+    FLAGS_OFFSET = Struct.offset_of :flags
+
     def ref
       Lib.g_param_spec_ref self
       self
@@ -12,6 +15,14 @@ module GObject
 
     def accessor_name
       get_name.tr('-', '_')
+    end
+
+    def value_type
+      to_ptr.get_gtype(VALUE_TYPE_OFFSET)
+    end
+
+    def flags
+      GObject::ParamFlags.get_value_from_pointer(to_ptr, FLAGS_OFFSET)
     end
   end
 end

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -39,15 +39,6 @@ module GirFFI
         @ancestor_infos ||= [info] + info.interfaces + parent_ancestor_infos
       end
 
-      def eligible_fields
-        info.fields.reject do |finfo|
-          fname = finfo.name
-          fname == 'parent_instance' ||
-            info.find_instance_method("get_#{fname}") ||
-            info.find_property(fname)
-        end
-      end
-
       def eligible_properties
         info.properties.reject do |pinfo|
           info.find_instance_method("get_#{pinfo.name}")
@@ -67,7 +58,6 @@ module GirFFI
         setup_layout
         setup_constants
         stub_methods
-        setup_field_accessors
         setup_property_accessors
         setup_vfunc_invokers
         setup_interfaces
@@ -97,12 +87,6 @@ module GirFFI
 
       def parent_ancestor_infos
         @parent_ancestor_infos ||= parent_builder.ancestor_infos
-      end
-
-      def setup_field_accessors
-        eligible_fields.each do |finfo|
-          FieldBuilder.new(finfo, klass).build
-        end
       end
 
       def setup_property_accessors

--- a/lib/gir_ffi/user_defined_property_info.rb
+++ b/lib/gir_ffi/user_defined_property_info.rb
@@ -76,7 +76,7 @@ module GirFFI
       end
 
       def interface_class
-        @interface_class ||= Builder.build_by_gtype @param_spec.value_type if interface?
+        @interface_class ||= Builder.build_by_gtype(value_type) if interface?
       end
 
       def interface_class_name

--- a/test/ffi-gobject/gobject_test.rb
+++ b/test/ffi-gobject/gobject_test.rb
@@ -63,9 +63,9 @@ describe GObject do
                                       10, 20, 15,
                                       3)
         spec.must_be_instance_of GObject::ParamSpecInt
-        spec.minimum.must_equal 10
-        spec.maximum.must_equal 20
-        spec.default_value.must_equal 15
+        spec.struct[:minimum].must_equal 10
+        spec.struct[:maximum].must_equal 20
+        spec.get_default_value.must_equal 15
       end
     end
   end

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -124,7 +124,7 @@ describe GObject::Object do
       skip 'cannot be reliably tested on JRuby and Rubinius' if jruby? || rubinius?
 
       ptr = GObject::Object.new.to_ptr
-      ref_count(ptr).must_equal 1
+      object_ref_count(ptr).must_equal 1
 
       GC.start
       # Creating a new object is sometimes needed to trigger enough garbage collection.
@@ -134,7 +134,7 @@ describe GObject::Object do
       GC.start
       GC.start
 
-      ref_count(ptr).must_equal 0
+      object_ref_count(ptr).must_equal 0
     end
   end
 end

--- a/test/ffi-gobject/param_spec_test.rb
+++ b/test/ffi-gobject/param_spec_test.rb
@@ -10,12 +10,13 @@ describe GObject::ParamSpec do
                            1, 3, 2,
                            readable: true, writable: true)
   end
+  let(:pspec_struct) { GObject::ParamSpec::Struct.new(pspec.to_ptr) }
 
   describe '#ref' do
     it 'increases the ref count' do
-      old = pspec.ref_count
+      old = pspec_struct[:ref_count]
       pspec.ref
-      pspec.ref_count.must_equal old + 1
+      pspec_struct[:ref_count].must_equal old + 1
     end
   end
 

--- a/test/ffi-gobject/value_test.rb
+++ b/test/ffi-gobject/value_test.rb
@@ -70,9 +70,9 @@ describe GObject::Value do
     it 'wraps object values' do
       value = GObject::Object.new({})
       gv = GObject::Value.wrap_ruby_value value
-      value.ref_count.must_equal 2
+      object_ref_count(value).must_equal 2
       gv.get_value.must_equal value
-      value.ref_count.must_equal 3
+      object_ref_count(value).must_equal 3
     end
   end
 

--- a/test/gir_ffi/builders/object_builder_test.rb
+++ b/test/gir_ffi/builders/object_builder_test.rb
@@ -79,23 +79,6 @@ describe GirFFI::Builders::ObjectBuilder do
     end
   end
 
-  describe '#eligible_fields' do
-    it 'skips fields that have a matching getter method' do
-      result = param_spec_builder.eligible_fields
-      result.map(&:name).wont_include 'name'
-    end
-
-    it 'skips fields that have a matching property' do
-      result = obj_builder.eligible_fields
-      result.map(&:name).wont_include 'hash_table'
-    end
-
-    it 'skips the parent instance field' do
-      result = obj_builder.eligible_fields
-      result.map(&:name).wont_include 'parent_instance'
-    end
-  end
-
   describe '#eligible_properties' do
     let(:wi_builder) do
       GirFFI::Builders::ObjectBuilder.new(

--- a/test/gir_ffi/builders/user_defined_builder_test.rb
+++ b/test/gir_ffi/builders/user_defined_builder_test.rb
@@ -185,15 +185,16 @@ describe GirFFI::Builders::UserDefinedBuilder do
         obj = derived_class.new
         object = GIMarshallingTests::Object.new 42
         obj.object_prop = object
-        object.ref_count.must_equal 2
+        object_ref_count(object).must_equal 2
       end
 
       it 'handles reference counting correctly when using the set_property method' do
         obj = derived_class.new
         object = GIMarshallingTests::Object.new 42
-        object.ref_count.must_equal 1
+
+        object_ref_count(object).must_equal 1
         obj.set_property('object_prop', object)
-        object.ref_count.must_equal 4 # Due to extra Value#set_value + Value#get_value
+        object_ref_count(object).must_equal 4 # Due to extra Value#set_value + Value#get_value
       end
     end
 

--- a/test/gir_ffi/sized_array_test.rb
+++ b/test/gir_ffi/sized_array_test.rb
@@ -117,7 +117,7 @@ describe GirFFI::SizedArray do
         arr.to_ptr.wont_be :autorelease?
 
         arr.to_a.must_equal [obj, nil]
-        obj.ref_count.must_equal 2
+        object_ref_count(obj).must_equal 2
       end
     end
 

--- a/test/gir_ffi_test_helper.rb
+++ b/test/gir_ffi_test_helper.rb
@@ -31,8 +31,8 @@ module GirFFITestExtensions
     SAVED_MODULES.delete name
   end
 
-  def ref_count(ptr)
-    GObject::Object::Struct.new(ptr)[:ref_count]
+  def object_ref_count(ptr)
+    GObject::Object::Struct.new(ptr.to_ptr)[:ref_count]
   end
 
   def max_for_unsigned_type(type)

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -302,12 +302,12 @@ describe GIMarshallingTests do
 
     it 'has a working function #full_inout' do
       ob = GIMarshallingTests::Object.new 42
-      ob.ref_count.must_equal 1
+      object_ref_count(ob).must_equal 1
 
       res = GIMarshallingTests::Object.full_inout ob
 
-      ob.ref_count.must_equal 1
-      res.ref_count.must_equal 1
+      object_ref_count(ob).must_equal 1
+      object_ref_count(res).must_equal 1
 
       res.must_be_instance_of GIMarshallingTests::Object
       res.int.must_equal 0
@@ -316,23 +316,23 @@ describe GIMarshallingTests do
     it 'has a working function #full_out' do
       res = GIMarshallingTests::Object.full_out
       res.must_be_instance_of GIMarshallingTests::Object
-      res.ref_count.must_equal 1
+      object_ref_count(res).must_equal 1
     end
 
     it 'has a working function #full_return' do
       res = GIMarshallingTests::Object.full_return
       res.must_be_instance_of GIMarshallingTests::Object
-      res.ref_count.must_equal 1
+      object_ref_count(res).must_equal 1
     end
 
     it 'has a working function #none_inout' do
       ob = GIMarshallingTests::Object.new 42
-      ob.ref_count.must_equal 1
+      object_ref_count(ob).must_equal 1
 
       res = GIMarshallingTests::Object.none_inout ob
 
-      ob.ref_count.must_equal 1
-      res.ref_count.must_equal 2
+      object_ref_count(ob).must_equal 1
+      object_ref_count(res).must_equal 2
 
       res.must_be_instance_of GIMarshallingTests::Object
       ob.int.must_equal 42
@@ -342,13 +342,13 @@ describe GIMarshallingTests do
     it 'has a working function #none_out' do
       res = GIMarshallingTests::Object.none_out
       res.must_be_instance_of GIMarshallingTests::Object
-      res.ref_count.must_equal 2
+      object_ref_count(res).must_equal 2
     end
 
     it 'has a working function #none_return' do
       res = GIMarshallingTests::Object.none_return
       res.must_be_instance_of GIMarshallingTests::Object
-      res.ref_count.must_equal 2
+      object_ref_count(res).must_equal 2
     end
 
     it 'has a working function #static_method' do
@@ -411,7 +411,7 @@ describe GIMarshallingTests do
       end
       result = derived_instance.
         get_ref_info_for_vfunc_in_object_transfer_none GIMarshallingTests::Object.gtype
-      obj.ref_count.must_be :>, 0
+      object_ref_count(obj).must_be :>, 0
       result.must_equal [2, false]
       obj.must_be_instance_of GIMarshallingTests::Object
     end
@@ -426,7 +426,7 @@ describe GIMarshallingTests do
         }
       end
       result = derived_instance.get_ref_info_for_vfunc_out_object_transfer_full
-      obj.ref_count.must_be :>, 0
+      object_ref_count(obj).must_be :>, 0
       # TODO: Check desired result
       result.must_equal [2, false]
     end
@@ -751,11 +751,6 @@ describe GIMarshallingTests do
     it 'does not have accessors for its parent instance' do
       instance.wont_respond_to :parent_instance
       instance.wont_respond_to :parent_instance=
-    end
-
-    it 'has a readable field long_' do
-      instance.long_.must_equal 0
-      instance.wont_respond_to :long_=
     end
   end
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1444,7 +1444,7 @@ describe Regress do
       end
 
       it 'has a reference count of 1' do
-        assert_equal 1, @o.ref_count
+        assert_equal 1, object_ref_count(@o)
       end
 
       it 'has been sunk' do
@@ -1463,17 +1463,18 @@ describe Regress do
     end
 
     let(:derived_instance) { Regress::TestFundamentalSubObject.new 'foo' }
+    let(:base_struct) { Regress::TestFundamentalObject::Struct.new derived_instance.to_ptr }
 
     it 'has a working method #ref' do
-      derived_instance.refcount.must_equal 1
+      base_struct[:refcount].must_equal 1
       derived_instance.ref
-      derived_instance.refcount.must_equal 2
+      base_struct[:refcount].must_equal 2
     end
 
     it 'has a working method #unref' do
-      derived_instance.refcount.must_equal 1
+      base_struct[:refcount].must_equal 1
       derived_instance.unref
-      derived_instance.refcount.must_equal 0
+      base_struct[:refcount].must_equal 0
     end
   end
 
@@ -1490,11 +1491,7 @@ describe Regress do
     end
 
     it 'has a field :data storing the constructor parameter' do
-      assert_equal 'foo', instance.data
-    end
-
-    it "can access its parent class' fields directly" do
-      instance.flags.must_equal 0
+      assert_equal 'foo', instance.struct[:data].to_utf8
     end
   end
 
@@ -1605,7 +1602,7 @@ describe Regress do
     end
 
     it 'has a reference count of 1' do
-      assert_equal 1, instance.ref_count
+      assert_equal 1, object_ref_count(instance)
     end
 
     it 'does not float' do
@@ -1687,9 +1684,9 @@ describe Regress do
 
     it 'has a working method #instance_method_full' do
       skip unless get_method_introspection_data('Regress', 'TestObj', 'instance_method_full')
-      instance.ref_count.must_equal 1
+      object_ref_count(instance).must_equal 1
       instance.instance_method_full
-      instance.ref_count.must_equal 1
+      object_ref_count(instance).must_equal 1
     end
 
     it 'has a working method #not_nullable_element_typed_gpointer_in' do
@@ -3211,7 +3208,7 @@ describe Regress do
     skip unless get_introspection_data 'Regress', 'test_callback_return_full'
     obj = Regress::TestObj.constructor
     Regress.test_callback_return_full { obj }
-    obj.ref_count.must_equal 1
+    object_ref_count(obj).must_equal 1
   end
 
   it 'has a working function #test_callback_thaw_async' do


### PR DESCRIPTION
Having direct accessors is dangerous and can lead to crashes. Object types should provide accessors in the form of properties and specialized methods, and if they don't overrides have to be provided.