### PR TITLE
Set byte array property

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 * Drop support for gobject-introspection below 1.46, the version available in
   Ubuntu Xenial.
+* Merge extended property getter and setter into regular ones. This means you
+  can always just use `#get_property` and `#set_property`. The methods
+  `#get_property_extended` and `#set_property_extended` are deprecated and will
+  be removed in GirFFI version 0.16 or later.
+* Support setting ByteArray properties directly with string values.
 
 ## 0.14.1 / 2018-09-27
 

--- a/lib/ffi-glib/byte_array.rb
+++ b/lib/ffi-glib/byte_array.rb
@@ -14,5 +14,14 @@ module GLib
       len = data.bytesize
       self.class.wrap Lib.g_byte_array_append(to_ptr, bytes, len)
     end
+
+    def self.from(data)
+      case data
+      when self
+        data
+      else
+        self.new.append(data)
+      end
+    end
   end
 end

--- a/lib/ffi-glib/byte_array.rb
+++ b/lib/ffi-glib/byte_array.rb
@@ -14,9 +14,5 @@ module GLib
       len = data.bytesize
       self.class.wrap Lib.g_byte_array_append(to_ptr, bytes, len)
     end
-
-    def initialize
-      store_pointer(Lib.g_byte_array_new)
-    end
   end
 end

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -117,6 +117,7 @@ module GObject
     setup_instance_method! 'get_property'
     setup_instance_method! 'set_property'
 
+    # @deprecated
     def get_property_extended(property_name)
       get_property(property_name)
     end
@@ -132,6 +133,7 @@ module GObject
       value
     end
 
+    # @deprecated
     def set_property_extended(property_name, value)
       set_property property_name, value
     end

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -210,6 +210,8 @@ module GObject
         GLib::List.from type_info.element_type, val
       when :strv
         GLib::Strv.from val
+      when :byte_array
+        GLib::ByteArray.from val
       when :callback
         GirFFI::Builder.build_class(type_info.interface).from val
       else

--- a/lib/gir_ffi/object_base.rb
+++ b/lib/gir_ffi/object_base.rb
@@ -49,8 +49,7 @@ module GirFFI
     # @return [GObjectIntrospection::IPropertyInfo] The property's info
     #
     def self.find_property(name)
-      gir_ffi_builder.find_property name or
-        raise GirFFI::PropertyNotFoundError.new(name, self)
+      gir_ffi_builder.find_property name
     end
 
     #

--- a/lib/gir_ffi/user_defined_object_info.rb
+++ b/lib/gir_ffi/user_defined_object_info.rb
@@ -37,6 +37,10 @@ module GirFFI
       nil
     end
 
+    def find_property(_property)
+      nil
+    end
+
     def parent_gtype
       @parent_gtype ||= GType.new(@klass.superclass.gtype)
     end

--- a/test/ffi-glib/byte_array_test.rb
+++ b/test/ffi-glib/byte_array_test.rb
@@ -19,4 +19,10 @@ describe GLib::ByteArray do
     ba = ba.append 'abdc'
     assert_equal 'abdc', ba.to_string
   end
+
+  it 'can be created from a string' do
+    str = 'cdba'
+    ba = GLib::ByteArray.from str
+    ba.to_string.must_equal str
+  end
 end

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -34,6 +34,12 @@ describe GObject::Object do
       instance = GObject::Object.new
       proc { instance.get_property 'foo-bar' }.must_raise GirFFI::PropertyNotFoundError
     end
+
+    it 'raises an error for a property that does not exist' do
+      instance = GObject::Object.new
+      proc { instance.get_property 'foo-bar' }.
+        must_raise GirFFI::PropertyNotFoundError
+    end
   end
 
   describe '#get_property_extended' do

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -852,14 +852,12 @@ describe GIMarshallingTests do
       end
 
       it 'can be set with #set_property' do
-        ba = GLib::ByteArray.new.append('some bytes')
-        instance.set_property 'some-byte-array', ba
+        instance.set_property 'some-byte-array', 'some bytes'
         instance.get_property('some-byte-array').to_string.must_equal 'some bytes'
       end
 
       it 'can be set with #some_byte_array=' do
-        ba = GLib::ByteArray.new.append('some bytes')
-        instance.some_byte_array = ba
+        instance.some_byte_array = 'some bytes'
         instance.some_byte_array.to_string.must_equal 'some bytes'
       end
     end

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -799,15 +799,15 @@ describe GIMarshallingTests do
         instance.some_boxed_glist.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended('some-boxed-glist', [1, 2, 3])
+      it 'can be set with #set_property' do
+        instance.set_property('some-boxed-glist', [1, 2, 3])
         instance.some_boxed_glist.to_a.must_equal [1, 2, 3]
       end
 
       it 'can be set with #some_boxed_glist=' do
         instance.some_boxed_glist = [1, 2, 3]
         instance.some_boxed_glist.to_a.must_equal [1, 2, 3]
-        instance.get_property_extended('some-boxed-glist').to_a.must_equal [1, 2, 3]
+        instance.get_property('some-boxed-glist').to_a.must_equal [1, 2, 3]
       end
     end
 
@@ -1063,8 +1063,8 @@ describe GIMarshallingTests do
         instance.some_strv.must_be :==, []
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended('some-strv', %w(foo bar))
+      it 'can be set with #set_property' do
+        instance.set_property('some-strv', %w(foo bar))
         instance.get_property('some-strv').must_be :==, %w(foo bar)
       end
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -247,16 +247,16 @@ describe Regress do
     end
 
     describe "its 'function-property' property" do
-      it 'can be retrieved with #get_property_extended' do
-        instance.get_property_extended('function-property').must_be_nil
+      it 'can be retrieved with #get_property' do
+        instance.get_property('function-property').must_be_nil
       end
 
       it 'can be retrieved with #function_property' do
         instance.function_property.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended('function-property', proc {})
+      it 'can be set with #set_property' do
+        instance.set_property('function-property', proc {})
         # AnnotationObject doesn't actually store stuff
         instance.function_property.must_be_nil
       end
@@ -264,7 +264,7 @@ describe Regress do
       it 'can be set with #function_property=' do
         instance.function_property = proc {}
         # AnnotationObject doesn't actually store stuff
-        instance.get_property_extended('function-property').must_be_nil
+        instance.get_property('function-property').must_be_nil
       end
     end
 
@@ -1908,15 +1908,15 @@ describe Regress do
         instance.hash_table.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended 'hash-table', 'foo' => -4, 'bar' => 83
+      it 'can be set with #set_property' do
+        instance.set_property 'hash-table', 'foo' => -4, 'bar' => 83
         instance.hash_table.to_hash.must_equal('foo' => -4, 'bar' => 83)
       end
 
       it 'can be set with #hash_table=' do
         instance.hash_table = { 'foo' => -4, 'bar' => 83 }
         instance.hash_table.to_hash.must_equal('foo' => -4, 'bar' => 83)
-        instance.get_property_extended('hash-table').to_hash.must_equal('foo' => -4,
+        instance.get_property('hash-table').to_hash.must_equal('foo' => -4,
                                                                         'bar' => 83)
       end
     end
@@ -1930,15 +1930,15 @@ describe Regress do
         instance.hash_table_old.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended 'hash-table-old', 'foo' => 34, 'bar' => -3
+      it 'can be set with #set_property' do
+        instance.set_property 'hash-table-old', 'foo' => 34, 'bar' => -3
         instance.hash_table_old.to_hash.must_equal('foo' => 34, 'bar' => -3)
       end
 
       it 'can be set with #hash_table_old=' do
         instance.hash_table_old = { 'foo' => 34, 'bar' => -3 }
         instance.hash_table_old.to_hash.must_equal('foo' => 34, 'bar' => -3)
-        instance.get_property_extended('hash-table-old').to_hash.must_equal('foo' => 34,
+        instance.get_property('hash-table-old').to_hash.must_equal('foo' => 34,
                                                                             'bar' => -3)
       end
     end
@@ -1965,44 +1965,44 @@ describe Regress do
     end
 
     describe "its 'list' property" do
-      it 'can be retrieved with #get_property_extended' do
-        instance.get_property_extended('list').must_be_nil
+      it 'can be retrieved with #get_property' do
+        instance.get_property('list').must_be_nil
       end
 
       it 'can be retrieved with #list' do
         instance.list.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended 'list', %w(foo bar)
+      it 'can be set with #set_property' do
+        instance.set_property 'list', %w(foo bar)
         instance.list.to_a.must_equal %w(foo bar)
       end
 
       it 'can be set with #list=' do
         instance.list = %w(foo bar)
         instance.list.to_a.must_equal %w(foo bar)
-        instance.get_property_extended('list').must_be :==, %w(foo bar)
+        instance.get_property('list').must_be :==, %w(foo bar)
       end
     end
 
     describe "its 'list-old' property" do
       it 'can be retrieved with #get_property' do
-        instance.get_property_extended('list-old').must_be_nil
+        instance.get_property('list-old').must_be_nil
       end
 
       it 'can be retrieved with #list_old' do
         instance.list_old.must_be_nil
       end
 
-      it 'can be set with #set_property_extended' do
-        instance.set_property_extended 'list-old', %w(foo bar)
+      it 'can be set with #set_property' do
+        instance.set_property 'list-old', %w(foo bar)
         instance.list_old.must_be :==, %w(foo bar)
       end
 
       it 'can be set with #list_old=' do
         instance.list_old = %w(foo bar)
         instance.list_old.must_be :==, %w(foo bar)
-        instance.get_property_extended('list-old').must_be :==, %w(foo bar)
+        instance.get_property('list-old').must_be :==, %w(foo bar)
       end
     end
 


### PR DESCRIPTION
* Allow setting byte array properties with just a string value.
* Merge extended property getter/setter functionality into the regular one.