### PR TITLE
Support newer gobject introspection

### DIFF
--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -283,10 +283,18 @@ describe GirFFI::Builder do
     end
 
     it 'sets up the inheritance chain' do
-      _(Regress::TestSubObj.registered_ancestors).
-        must_equal [Regress::TestSubObj,
+      # Introduced in version 1.59.1
+      expected = if Regress::TestSubObj.find_property :boolean
+                   [Regress::TestSubObj,
+                    Regress::TestInterface,
                     Regress::TestObj,
                     GObject::Object]
+                 else
+                   [Regress::TestSubObj,
+                    Regress::TestObj,
+                    GObject::Object]
+                 end
+      _(Regress::TestSubObj.registered_ancestors).must_equal expected
     end
 
     it 'creates a Regress::TestSubObj#to_ptr method' do

--- a/test/gir_ffi/builders/union_builder_test.rb
+++ b/test/gir_ffi/builders/union_builder_test.rb
@@ -3,7 +3,7 @@
 require 'gir_ffi_test_helper'
 
 describe GirFFI::Builders::UnionBuilder do
-  let(:union_info) { get_introspection_data('GObject', 'TypeCValue') }
+  let(:union_info) { get_introspection_data('Regress', 'FooBUnion') }
   let(:builder) { GirFFI::Builders::UnionBuilder.new union_info }
 
   describe '#setup_instance_method' do
@@ -13,13 +13,10 @@ describe GirFFI::Builders::UnionBuilder do
   end
 
   describe '#layout_specification' do
-    it 'returns the correct layout for GObject::TypeCValue' do
-      long_type = FFI.type_size(:long) == 8 ? :int64 : :int32
-      _(builder.layout_specification).must_equal [:v_int, :int32, 0,
-                                                  :v_long, long_type, 0,
-                                                  :v_int64, :int64, 0,
-                                                  :v_double, :double, 0,
-                                                  :v_pointer, :pointer, 0]
+    it 'returns the correct layout for Regress::FooBUnion' do
+      _(builder.layout_specification).must_equal [:type, :int32, 0,
+                                                  :v, :double, 0,
+                                                  :rect, :pointer, 0]
     end
   end
 

--- a/test/integration/generated_gtk_source_test.rb
+++ b/test/integration/generated_gtk_source_test.rb
@@ -10,11 +10,22 @@ describe 'The generated GtkSource module' do
     let(:instance) { GtkSource::CompletionContext.new }
 
     it 'allows adding proposals' do
-      proposals = [
-        GtkSource::CompletionItem.new('Proposal 1', 'Proposal 1', nil, 'blah 1'),
-        GtkSource::CompletionItem.new('Proposal 2', 'Proposal 2', nil, 'blah 2'),
-        GtkSource::CompletionItem.new('Proposal 3', 'Proposal 3', nil, 'blah 3')
-      ]
+      # Interface changed in GtkSourceView 3.24
+      proposals = if GtkSource::CompletionItem.instance_methods.include? :set_label
+                    Array.new(3) do |i|
+                      GtkSource::CompletionItem.new.tap do |item|
+                        item.label = "Proposal #{i}"
+                        item.text =  "Proposal #{i}"
+                        item.info = "blah #{i}"
+                      end
+                    end
+                  else
+                    [
+                      GtkSource::CompletionItem.new('Proposal 1', 'Proposal 1', nil, 'blah 1'),
+                      GtkSource::CompletionItem.new('Proposal 2', 'Proposal 2', nil, 'blah 2'),
+                      GtkSource::CompletionItem.new('Proposal 3', 'Proposal 3', nil, 'blah 3')
+                    ]
+                  end
       instance.add_proposals nil, proposals, true
     end
   end


### PR DESCRIPTION
Update tests for changes to GObjectIntrospection

* TestSubObj ancestry was changed
* Some fields and methods are no longer exposed