### PR TITLE
Support unintrospectable classes not derived from GObject

### DIFF
--- a/lib/gir_ffi/builder.rb
+++ b/lib/gir_ffi/builder.rb
@@ -19,11 +19,17 @@ module GirFFI
 
     def self.build_by_gtype(gtype)
       info = GObjectIntrospection::IRepository.default.find_by_gtype gtype
-      info ||= case GObject.type_fundamental gtype
-               when GObject::TYPE_BOXED
-                 UnintrospectableBoxedInfo.new gtype
-               when GObject::TYPE_OBJECT
-                 UnintrospectableTypeInfo.new gtype
+      info ||= begin
+                 fund = GObject.type_fundamental gtype
+                 if fund == GObject::TYPE_BOXED
+                   UnintrospectableBoxedInfo.new gtype
+                 elsif fund == GObject::TYPE_OBJECT
+                   UnintrospectableTypeInfo.new gtype
+                 elsif fund >= GObject::TYPE_RESERVED_USER_FIRST
+                   UnintrospectableTypeInfo.new gtype
+                 else
+                   raise "Unable to handle type #{GObject.type_name gtype}"
+                 end
                end
 
       build_class info

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -78,6 +78,15 @@ describe GirFFI::Builder do
       _(found_klass).must_equal klass
     end
 
+    it "returns the class for user-defined types not derived from GObject" do
+      klass = Class.new Regress::TestFundamentalObject
+      Object.const_set "Derived#{Sequence.next}", klass
+      gtype = GirFFI.define_type klass
+
+      found_klass = GirFFI::Builder.build_by_gtype gtype
+      _(found_klass).must_equal klass
+    end
+
     it "returns a valid class for boxed classes unknown to GIR" do
       object_class = GIMarshallingTests::PropertiesObject.object_class
       property = object_class.find_property "some-boxed-glist"

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -89,6 +89,11 @@ describe GirFFI::Builder do
       _(found_klass.name).must_be_nil
       _(found_klass.superclass).must_equal GirFFI::BoxedBase
     end
+
+    it "refuse to build classes for base types" do
+      _(-> { GirFFI::Builder.build_by_gtype GObject::TYPE_INT }).
+        must_raise RuntimeError, "Unable to handle type gint"
+    end
   end
 
   describe ".attach_ffi_function" do

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -3458,6 +3458,8 @@ describe Regress do
     skip_below "1.51.2"
     instance = Regress.test_create_fundamental_hidden_class_instance
     _(instance).must_be_kind_of Regress::TestFundamentalObject
+    g_type = instance.object_class.g_type
+    _(GObject.type_name g_type).must_equal "RegressTestFundamentalHiddenSubObject"
   end
 
   it "has a working function #test_date_in_gvalue" do

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -3455,7 +3455,9 @@ describe Regress do
   end
 
   it "has a working function #test_create_fundamental_hidden_class_instance" do
-    skip "Needs testing"
+    skip_below "1.51.2"
+    instance = Regress.test_create_fundamental_hidden_class_instance
+    _(instance).must_be_kind_of Regress::TestFundamentalObject
   end
 
   it "has a working function #test_date_in_gvalue" do


### PR DESCRIPTION
Type hierarchies can be created based on some fundamental type other than GObject. Support creating a Ruby class for an unintrospectable type in such a hierarchy.