### PR TITLE
Fix receiver handing for struct instance methods

### DIFF
--- a/lib/gir_ffi/builders/function_builder.rb
+++ b/lib/gir_ffi/builders/function_builder.rb
@@ -37,11 +37,16 @@ module GirFFI
       private
 
       def receiver_call_argument
-        if @info.instance_ownership_transfer == :everything
+        container_type_info = ReceiverTypeInfo.new(container_info)
+        if @info.instance_ownership_transfer == :everything && container_type_info.flattened_tag == :object
           "self.ref"
         else
           "self"
         end
+      end
+
+      def container_info
+        @container_info ||= @info.container
       end
     end
   end

--- a/lib/gir_ffi/receiver_type_info.rb
+++ b/lib/gir_ffi/receiver_type_info.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module GirFFI
-  # Represents the type of the receiver of a signal or vfunc, conforming, as
-  # needed, to the interface of GObjectIntrospection::ITypeInfo
+  # Represents the type of the receiver of a signal, vfunc, or method,
+  # conforming, as needed, to the interface of GObjectIntrospection::ITypeInfo
   class ReceiverTypeInfo
     include InfoExt::ITypeInfo
 

--- a/test/gir_ffi/builders/function_builder_test.rb
+++ b/test/gir_ffi/builders/function_builder_test.rb
@@ -401,6 +401,24 @@ describe GirFFI::Builders::FunctionBuilder do
     end
 
     describe "struct ownership transfer" do
+      describe "for Regress::FooRectangle#add" do
+        let(:function_info) do
+          get_method_introspection_data("Regress", "FooRectangle",
+                                        "add")
+        end
+
+        it "builds a correct definition without #ref" do
+          _(code).must_equal <<~CODE
+          def add(r2)
+            _v1 = Regress::FooRectangle.from(r2)
+            Regress::Lib.regress_foo_rectangle_add self, _v1
+          end
+          CODE
+        end
+      end
+    end
+
+    describe "boxed struct ownership transfer" do
       describe "for GIMarshallingTests::BoxedStruct.inout" do
         let(:function_info) do
           get_method_introspection_data("GIMarshallingTests", "BoxedStruct", "inout")

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -855,7 +855,8 @@ describe Regress do
     it "has a working method #add" do
       other_instance = Regress::FooRectangle.new
       result = instance.add other_instance
-      _(result).must_equal other_instance
+      # NOTE: inout annotation has no effect on the method receiver
+      _(result).must_be_nil
     end
   end
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -853,9 +853,9 @@ describe Regress do
     end
 
     it "has a working method #add" do
-      skip "Not implemented yet"
       other_instance = Regress::FooRectangle.new
-      instance.add other_instance
+      result = instance.add other_instance
+      _(result).must_equal other_instance
     end
   end
 


### PR DESCRIPTION
Avoids calling `ref` on structs when transfer is `:everything`.