### PR TITLE
Only load simplecov when running full test suite

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,4 @@
+SimpleCov.start do
+  track_files "lib/**/*.rb"
+  add_filter "/test/"
+end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -156,9 +156,10 @@ namespace :test do
   task overrides: :lib
   task integration: :lib
 
-  desc 'Run the entire test suite as one'
+  desc 'Run the entire test suite as one with simplecov activated'
   define_test_task(:all) do |t|
     t.test_files = FileList['test/**/*_test.rb']
+    t.ruby_opts += ['-rbundler/setup -rsimplecov -w -Itest']
   end
 
   task all: :lib

--- a/test/base_test_helper.rb
+++ b/test/base_test_helper.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "simplecov"
-SimpleCov.start do
-  track_files "lib/**/*.rb"
-  add_filter "/test/"
-end
-
 if ENV["CI"]
   begin
     require "coveralls"


### PR DESCRIPTION
This speeds up test runs when only running part of the suite or a single test file.