### PR TITLE
Generate accessor aliases

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -90,22 +90,6 @@ module GObject
       end
     end
 
-    # TODO: Generate accessor methods from GIR at class definition time
-    def method_missing(method, *args)
-      getter_name = "get_#{method}"
-      return send(getter_name, *args) if respond_to?(getter_name)
-
-      if method.to_s =~ /(.*)=$/
-        setter_name = "set_#{Regexp.last_match[1]}"
-        return send(setter_name, *args) if respond_to?(setter_name)
-      end
-      super
-    end
-
-    def respond_to_missing?(*)
-      false
-    end
-
     def signal_connect(event, data = nil, &block)
       GObject.signal_connect(self, event, data, &block)
     end

--- a/lib/ffi-gobject_introspection/i_base_info.rb
+++ b/lib/ffi-gobject_introspection/i_base_info.rb
@@ -107,6 +107,7 @@ module GObjectIntrospection
       namespace.sub(/^[a-z]/, &:upcase)
     end
 
+    # TODO: Avoid calling for IStructInfo
     def container
       @container ||= begin
                        ptr = Lib.g_base_info_get_container self

--- a/lib/gir_ffi/builders/field_builder.rb
+++ b/lib/gir_ffi/builders/field_builder.rb
@@ -291,6 +291,7 @@ module GirFFI
 
       attr_reader :container_class
 
+      # TODO: Inject container_info on initialization
       def container_info
         @container_info ||= info.container
       end

--- a/lib/gir_ffi/builders/property_builder.rb
+++ b/lib/gir_ffi/builders/property_builder.rb
@@ -143,6 +143,7 @@ module GirFFI
         @container_module ||= Object.const_get(container_info.safe_namespace)
       end
 
+      # TODO: Inject container_info on initialization
       def container_info
         @container_info ||= @info.container
       end

--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -95,9 +95,9 @@ module GirFFI
       end
 
       def alias_accessors(minfo)
-        if minfo.name =~ /^get_(.*)/
+        if minfo.n_args == 0 && minfo.name =~ /^get_(.*)/
           klass.alias_method Regexp.last_match(1), minfo.name
-        elsif minfo.name =~ /^set_(.*)/
+        elsif minfo.n_args == 1 && minfo.name =~ /^set_(.*)/
           klass.alias_method "#{Regexp.last_match(1)}=", minfo.name
         end
       end

--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -77,6 +77,12 @@ module GirFFI
       def stub_methods
         info.get_methods.each do |minfo|
           klass.class_eval MethodStubber.new(minfo).method_stub, __FILE__, __LINE__
+          if minfo.name =~ /^get_(.*)/ && minfo.method?
+            klass.alias_method $1, minfo.name
+          end
+          if minfo.name =~ /^set_(.*)/ && minfo.method?
+            klass.alias_method "#{$1}=", minfo.name
+          end
         end
       end
 

--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -77,12 +77,7 @@ module GirFFI
       def stub_methods
         info.get_methods.each do |minfo|
           klass.class_eval MethodStubber.new(minfo).method_stub, __FILE__, __LINE__
-          if minfo.name =~ /^get_(.*)/ && minfo.method?
-            klass.alias_method Regexp.last_match(1), minfo.name
-          end
-          if minfo.name =~ /^set_(.*)/ && minfo.method?
-            klass.alias_method "#{Regexp.last_match(1)}=", minfo.name
-          end
+          alias_accessors(minfo) if minfo.method?
         end
       end
 
@@ -97,6 +92,14 @@ module GirFFI
 
       def fields
         info.fields
+      end
+
+      def alias_accessors(minfo)
+        if minfo.name =~ /^get_(.*)/
+          klass.alias_method Regexp.last_match(1), minfo.name
+        elsif minfo.name =~ /^set_(.*)/
+          klass.alias_method "#{Regexp.last_match(1)}=", minfo.name
+        end
       end
     end
   end

--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -78,10 +78,10 @@ module GirFFI
         info.get_methods.each do |minfo|
           klass.class_eval MethodStubber.new(minfo).method_stub, __FILE__, __LINE__
           if minfo.name =~ /^get_(.*)/ && minfo.method?
-            klass.alias_method $1, minfo.name
+            klass.alias_method Regexp.last_match(1), minfo.name
           end
           if minfo.name =~ /^set_(.*)/ && minfo.method?
-            klass.alias_method "#{$1}=", minfo.name
+            klass.alias_method "#{Regexp.last_match(1)}=", minfo.name
           end
         end
       end

--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -96,9 +96,9 @@ module GirFFI
 
       def alias_accessors(minfo)
         if minfo.n_args == 0 && minfo.name =~ /^get_(.*)/
-          klass.alias_method Regexp.last_match(1), minfo.name
+          klass.send :alias_method, Regexp.last_match(1), minfo.name
         elsif minfo.n_args == 1 && minfo.name =~ /^set_(.*)/
-          klass.alias_method "#{Regexp.last_match(1)}=", minfo.name
+          klass.send :alias_method, "#{Regexp.last_match(1)}=", minfo.name
         end
       end
     end

--- a/test/ffi-glib/bytes_test.rb
+++ b/test/ffi-glib/bytes_test.rb
@@ -13,6 +13,11 @@ describe GLib::Bytes do
     _(bytes.get_size).must_equal 3
   end
 
+  it "has #size as an alias for #get_size" do
+    bytes = GLib::Bytes.new [1, 2, 3]
+    _(bytes.size).must_equal 3
+  end
+
   it "has a working #get_data method" do
     bytes = GLib::Bytes.new [1, 2, 3]
     _(bytes.get_data.to_a).must_equal [1, 2, 3]

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -65,30 +65,6 @@ describe GObject::Object do
     end
   end
 
-  describe "automatic accessor methods" do
-    class AccessorTest < GObject::Object
-      def get_x
-        @x
-      end
-
-      def set_x(val)
-        @x = val
-      end
-    end
-
-    subject { AccessorTest.new }
-
-    it "reads x by calling get_x" do
-      subject.set_x(1)
-      assert_equal 1, subject.x
-    end
-
-    it "writes x by calling set_x" do
-      subject.x = 2
-      assert_equal 2, subject.x
-    end
-  end
-
   describe "#signal_connect" do
     subject { GObject::Object.new }
 

--- a/test/gir_ffi/builders/registered_type_builder_test.rb
+++ b/test/gir_ffi/builders/registered_type_builder_test.rb
@@ -38,5 +38,17 @@ describe GirFFI::Builders::RegisteredTypeBuilder do
       instance = Regress::TestWi8021x.new
       _(instance).must_respond_to :testbool=
     end
+
+    it "does not add getter alias for method with arguments" do
+      instance = Regress::TestObj.constructor
+      _(instance).must_respond_to :get_qdata
+      _(instance).wont_respond_to :qdata
+    end
+
+    it "does not add getter alias for method with more than one argument" do
+      instance = Regress::TestObj.constructor
+      _(instance).must_respond_to :get_qdata
+      _(instance).wont_respond_to :qdata
+    end
   end
 end

--- a/test/gir_ffi/builders/registered_type_builder_test.rb
+++ b/test/gir_ffi/builders/registered_type_builder_test.rb
@@ -27,4 +27,16 @@ describe GirFFI::Builders::RegisteredTypeBuilder do
       skip "Need some way to test this now that GLib::IConv is gone"
     end
   end
+
+  describe "#stub_methods" do
+    it "adds getter method aliases" do
+      instance = Regress::TestWi8021x.new
+      _(instance).must_respond_to :testbool
+    end
+
+    it "adds setter method aliases" do
+      instance = Regress::TestWi8021x.new
+      _(instance).must_respond_to :testbool=
+    end
+  end
 end

--- a/test/integration/generated_gobject_test.rb
+++ b/test/integration/generated_gobject_test.rb
@@ -103,12 +103,22 @@ describe GObject do
   end
 
   describe GObject::ParamSpec do
-    it "does not have a separate #name field accessor" do
+    it "has a generated field accessor for #flags but not #get_flags method" do
       pspec = GObject.param_spec_int("foo", "foo bar",
                                      "The Foo Bar Property",
                                      10, 20, 15,
                                      3)
-      _(pspec).wont_respond_to :name
+      _(pspec).wont_respond_to :get_flags
+      _(pspec.method(:flags).original_name).must_equal :flags
+    end
+
+    it "aliases #get_name to #name instead of having a separate field accessor" do
+      pspec = GObject.param_spec_int("foo", "foo bar",
+                                     "The Foo Bar Property",
+                                     10, 20, 15,
+                                     3)
+      _(pspec).must_respond_to :get_name
+      _(pspec.method(:name).original_name).must_equal :get_name
     end
   end
 end


### PR DESCRIPTION
Instead of relying on `method_missing`, generate appropriate aliases to methods that have a getter- or setter-like name.