### PR TITLE
Also alias getter methods with arguments

### DIFF
--- a/lib/gir_ffi/builders/registered_type_builder.rb
+++ b/lib/gir_ffi/builders/registered_type_builder.rb
@@ -95,7 +95,7 @@ module GirFFI
       end
 
       def alias_accessors(minfo)
-        if minfo.n_args == 0 && minfo.name =~ /^get_(.*)/
+        if minfo.name =~ /^get_(.*)/
           klass.send :alias_method, Regexp.last_match(1), minfo.name
         elsif minfo.n_args == 1 && minfo.name =~ /^set_(.*)/
           klass.send :alias_method, "#{Regexp.last_match(1)}=", minfo.name

--- a/test/gir_ffi/builders/registered_type_builder_test.rb
+++ b/test/gir_ffi/builders/registered_type_builder_test.rb
@@ -39,16 +39,16 @@ describe GirFFI::Builders::RegisteredTypeBuilder do
       _(instance).must_respond_to :testbool=
     end
 
-    it "does not add getter alias for method with arguments" do
+    it "adds getter alias for method with arguments" do
       instance = Regress::TestObj.constructor
       _(instance).must_respond_to :get_qdata
-      _(instance).wont_respond_to :qdata
+      _(instance).must_respond_to :qdata
     end
 
-    it "does not add getter alias for method with more than one argument" do
+    it "does not add setter alias for method with more than one argument" do
       instance = Regress::TestObj.constructor
-      _(instance).must_respond_to :get_qdata
-      _(instance).wont_respond_to :qdata
+      _(instance).must_respond_to :set_data
+      _(instance).wont_respond_to :data=
     end
   end
 end


### PR DESCRIPTION
It makes sense to alias, e.g., `get_child(index)`, to `child(index)`. On the other hand, aliasing the corresponding setter is weird, since assignment only takes one parameter.