### PR TITLE
Reduce Gtk+ dependency

### DIFF
--- a/test/gir_ffi/builders/object_builder_test.rb
+++ b/test/gir_ffi/builders/object_builder_test.rb
@@ -17,20 +17,20 @@ describe GirFFI::Builders::ObjectBuilder do
   end
 
   describe "#find_signal" do
-    it 'finds the signal "test" for TestObj' do
+    it 'finds a signal defined on the class itself' do
       sig = obj_builder.find_signal "test"
       _(sig.name).must_equal "test"
     end
 
-    it 'finds the signal "test" for TestSubObj' do
+    it 'finds a signal defined on a superclass' do
       sig = sub_obj_builder.find_signal "test"
       _(sig.name).must_equal "test"
     end
 
-    it 'finds the signal "changed" for Gtk::Entry' do
-      builder = GirFFI::Builders::ObjectBuilder.new get_introspection_data("Gtk", "Entry")
-      sig = builder.find_signal "changed"
-      _(sig.name).must_equal "changed"
+    it 'finds signals defined on interfaces' do
+      skip_below "1.57.2"
+      sig = sub_obj_builder.find_signal "interface-signal"
+      _(sig.name).must_equal "interface-signal"
     end
 
     it "returns nil for a signal that doesn't exist" do

--- a/test/gir_ffi/builders/signal_closure_builder_test.rb
+++ b/test/gir_ffi/builders/signal_closure_builder_test.rb
@@ -134,20 +134,21 @@ describe GirFFI::Builders::SignalClosureBuilder do
       end
     end
 
-    describe "for a signal returning an string" do
+    describe "for a signal returning a string" do
       let(:signal_info) do
-        get_signal_introspection_data "Gtk", "Scale", "format-value"
+        get_signal_introspection_data "Regress", "AnnotationObject", "attribute-signal"
       end
 
       it "returns a mapping method that passes the string result to return_value directly" \
         do
         expected = <<~CODE
           def self.marshaller(closure, return_value, param_values, _invocation_hint, _marshal_data)
-            _instance, value = param_values.map(&:get_value_plain)
+            _instance, arg1, arg2 = param_values.map(&:get_value_plain)
             _v1 = _instance
-            _v2 = value
-            _v3 = wrap(closure.to_ptr).invoke_block(_v1, _v2)
-            return_value.set_value _v3
+            _v2 = arg1
+            _v3 = arg2
+            _v4 = wrap(closure.to_ptr).invoke_block(_v1, _v2, _v3)
+            return_value.set_value _v4
           end
         CODE
 


### PR DESCRIPTION
This replaces two tests that depended on Gtk+' introspection data with tests that use data from the Regress test library. For the signal test, this also stops the test from failing in case Gtk+ 4 introspection data is present and the test is run either stand-alone or via the `test:main` task. When running the `test:all` task the test won't fail since the `GtkSource` integration test loads the Gtk+ 3.0 data under the hood when setting up `GtkSource`.