### PR TITLE
Improve callback class names

### DIFF
--- a/lib/ffi-gobject_introspection/i_base_info.rb
+++ b/lib/ffi-gobject_introspection/i_base_info.rb
@@ -107,10 +107,10 @@ module GObjectIntrospection
       namespace.sub(/^[a-z]/, &:upcase)
     end
 
-    # TODO: Avoid calling for IStructInfo
     def container
       @container ||= begin
                        ptr = Lib.g_base_info_get_container self
+                       return if ptr.null?
                        Lib.g_base_info_ref ptr
                        IRepository.wrap_ibaseinfo_pointer ptr
                      end

--- a/lib/gir_ffi/builder_helper.rb
+++ b/lib/gir_ffi/builder_helper.rb
@@ -12,7 +12,12 @@ module GirFFI
     end
 
     def get_or_define_class(namespace, name, parent)
-      optionally_define_constant(namespace, name) { Class.new parent }
+      klass = optionally_define_constant(namespace, name) { Class.new parent }
+      unless klass.superclass == parent
+        raise "Expected superclass #{parent}, found #{klass.superclass}"
+      end
+
+      klass
     end
 
     def get_or_define_module(parent, name)

--- a/lib/gir_ffi/builders/callback_builder.rb
+++ b/lib/gir_ffi/builders/callback_builder.rb
@@ -23,7 +23,19 @@ module GirFFI
       end
 
       def klass
-        @klass ||= get_or_define_class namespace_module, @classname, CallbackBase
+        @klass ||= get_or_define_class container_module, @classname, CallbackBase
+      end
+
+      def container_module
+        @container_module ||=
+          if @info.container
+            type_info = @info.container
+            field_info = type_info.container
+            container_class_info = field_info.container
+            namespace_module.const_get container_class_info.safe_name
+          else
+            namespace_module
+          end
       end
 
       def mapping_method_definition

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1674,6 +1674,13 @@ describe Regress do
       instance.emit_sig_with_int64
     end
 
+    it "defines signal type Sig_with_int64_prop in the class namespace" do
+      instance.signal_connect("sig-with-int64-prop") { |_obj, i, _ud| i }
+      instance.emit_sig_with_int64
+      _(Regress::TestObj.const_defined? :Sig_with_int64_prop).must_equal true
+      _(Regress.const_defined? :Sig_with_int64_prop).must_equal false
+    end
+
     it "has a working method #emit_sig_with_null_error" do
       skip_below "1.61.1"
       error = nil

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1621,6 +1621,11 @@ describe Regress do
       _(instance).wont_be :floating?
     end
 
+    it "defines callback type Matrix in the metaclass namespace" do
+      _(Regress::TestObjClass.const_defined? :Matrix).must_equal true
+      _(Regress.const_defined? :Matrix).must_equal false
+    end
+
     it "has a working method #matrix" do
       _(instance.matrix("bar")).must_equal 42
     end


### PR DESCRIPTION
This stores callback classes that are internal to fields inside the classes defining those fields.

This avoids problems where a class may define an internal callback field with a name that clashes with some other class.