### PR TITLE
Support disguised object class structs

### DIFF
--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -106,7 +106,5 @@ module GObject
 
     attach_function :g_param_spec_ref, [:pointer], :pointer
     attach_function :g_param_spec_sink, [:pointer], :pointer
-
-    attach_function :g_type_class_ref, [:size_t], :pointer
   end
 end

--- a/lib/ffi-gobject/object_class.rb
+++ b/lib/ffi-gobject/object_class.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-GObject.load_class :ObjectClass
+GObject::Object.object_class
 
 module GObject
   # Overrides for GObjectClass, a struct containing GObject's class data

--- a/lib/gir_ffi-base/gobject/lib.rb
+++ b/lib/gir_ffi-base/gobject/lib.rb
@@ -7,9 +7,13 @@ module GObject
   module Lib
     extend FFI::Library
     extend FFI::BitMasks
+
     ffi_lib "gobject-2.0"
+
     attach_function :g_type_from_name, [:string], :size_t
     attach_function :g_type_fundamental, [:size_t], :size_t
+    attach_function :g_type_class_ref, [:size_t], :pointer
+
     attach_function :g_array_get_type, [], :size_t
     attach_function :g_byte_array_get_type, [], :size_t
     attach_function :g_error_get_type, [], :size_t

--- a/lib/gir_ffi/builder_helper.rb
+++ b/lib/gir_ffi/builder_helper.rb
@@ -11,9 +11,12 @@ module GirFFI
       end
     end
 
-    def get_or_define_class(namespace, name, parent)
-      klass = optionally_define_constant(namespace, name) { Class.new parent }
-      unless klass.superclass == parent
+    def get_or_define_class(namespace, name, parent = nil)
+      klass = optionally_define_constant(namespace, name) do
+        parent ||= yield
+        Class.new parent
+      end
+      if parent && klass.superclass != parent
         raise "Expected #{klass} to have superclass #{parent}, found #{klass.superclass}"
       end
 

--- a/lib/gir_ffi/builder_helper.rb
+++ b/lib/gir_ffi/builder_helper.rb
@@ -14,7 +14,7 @@ module GirFFI
     def get_or_define_class(namespace, name, parent)
       klass = optionally_define_constant(namespace, name) { Class.new parent }
       unless klass.superclass == parent
-        raise "Expected superclass #{parent}, found #{klass.superclass}"
+        raise "Expected #{klass} to have superclass #{parent}, found #{klass.superclass}"
       end
 
       klass

--- a/lib/gir_ffi/builders/class_struct_builder.rb
+++ b/lib/gir_ffi/builders/class_struct_builder.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "gir_ffi/builders/struct_builder"
+
+module GirFFI
+  module Builders
+    # Implements the creation of a class representing a Struct.
+    class ClassStructBuilder < RegisteredTypeBuilder
+      include StructLike
+
+      attr_reader :superclass
+
+      def initialize(info, super_class_struct)
+        @superclass = super_class_struct
+        super info
+        raise "Info does not represent gtype_struct" unless info.gtype_struct?
+      end
+
+      def layout_superclass
+        GirFFI::Struct
+      end
+    end
+  end
+end

--- a/lib/gir_ffi/builders/interface_builder.rb
+++ b/lib/gir_ffi/builders/interface_builder.rb
@@ -8,7 +8,9 @@ module GirFFI
     # Implements the creation of a module representing an Interface.
     class InterfaceBuilder < RegisteredTypeBuilder
       def interface_struct
-        @interface_struct ||= Builder.build_class iface_struct_info
+        @interface_struct ||=
+          ClassStructBuilder.new(iface_struct_info,
+                                 GObject::TypeInterface).build_class
       end
 
       private

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -39,9 +39,8 @@ module GirFFI
       def object_class_struct
         @object_class_struct ||=
           if object_class_struct_info
-            class_struct_builder = ClassStructBuilder.new(object_class_struct_info,
-                                                          parent_builder.object_class_struct)
-            class_struct_builder.build_class
+            ClassStructBuilder.new(object_class_struct_info,
+                                   parent_builder.object_class_struct).build_class
           else
             parent_builder.object_class_struct
           end

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -3,6 +3,7 @@
 require "gir_ffi/builders/registered_type_builder"
 require "gir_ffi/builders/with_layout"
 require "gir_ffi/builders/property_builder"
+require "gir_ffi/builders/class_struct_builder"
 require "gir_ffi/object_base"
 require "gir_ffi/struct"
 
@@ -16,6 +17,10 @@ module GirFFI
       class ObjectBaseBuilder
         def build_class
           ObjectBase
+        end
+
+        def object_class_struct
+          GObject::TypeClass
         end
 
         def ancestor_infos
@@ -34,7 +39,9 @@ module GirFFI
       def object_class_struct
         @object_class_struct ||=
           if object_class_struct_info
-            Builder.build_class object_class_struct_info
+            class_struct_builder = ClassStructBuilder.new(object_class_struct_info,
+                                                          parent_builder.object_class_struct)
+            class_struct_builder.build_class
           else
             parent_builder.object_class_struct
           end

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -32,7 +32,12 @@ module GirFFI
       end
 
       def object_class_struct
-        @object_class_struct ||= Builder.build_class object_class_struct_info
+        @object_class_struct ||=
+          if object_class_struct_info
+            Builder.build_class object_class_struct_info
+          else
+            parent_builder.object_class_struct
+          end
       end
 
       def ancestor_infos
@@ -48,8 +53,7 @@ module GirFFI
       protected
 
       def object_class_struct_info
-        @object_class_struct_info ||=
-          info.class_struct || parent_builder.object_class_struct_info
+        @object_class_struct_info ||= info.class_struct
       end
 
       private

--- a/lib/gir_ffi/builders/struct_builder.rb
+++ b/lib/gir_ffi/builders/struct_builder.rb
@@ -25,6 +25,10 @@ module GirFFI
         StructBase
       end
 
+      def klass
+        @klass ||= get_or_define_class(namespace_module, @classname) { superclass }
+      end
+
       def parent_field_type
         fields.first.field_type
       end

--- a/lib/gir_ffi/builders/struct_builder.rb
+++ b/lib/gir_ffi/builders/struct_builder.rb
@@ -15,11 +15,7 @@ module GirFFI
       end
 
       def superclass
-        # HACK: Inheritance chain is not expressed in GObject's code correctly.
-        if info.full_type_name == "GObject::InitiallyUnownedClass"
-          return GObject::ObjectClass
-        end
-        return parent_field_type.tag_or_class if info.gtype_struct?
+        raise "Use ClassStructBuilder to build #{info.full_type_name}" if info.gtype_struct?
         return BoxedBase if GObject.type_fundamental(info.gtype) == GObject::TYPE_BOXED
 
         StructBase

--- a/lib/gir_ffi/unintrospectable_type_info.rb
+++ b/lib/gir_ffi/unintrospectable_type_info.rb
@@ -56,7 +56,7 @@ module GirFFI
 
     # TODO: Create custom class that includes the interfaces instead
     def class_struct
-      parent.class_struct
+      nil
     end
   end
 end

--- a/lib/gir_ffi/user_defined_object_info.rb
+++ b/lib/gir_ffi/user_defined_object_info.rb
@@ -51,7 +51,7 @@ module GirFFI
 
     # TODO: Create custom class that includes the interfaces instead
     def class_struct
-      parent.class_struct
+      nil
     end
 
     def interfaces

--- a/test/gir_ffi/builders/object_builder_test.rb
+++ b/test/gir_ffi/builders/object_builder_test.rb
@@ -64,6 +64,13 @@ describe GirFFI::Builders::ObjectBuilder do
       builder = GirFFI::Builders::ObjectBuilder.new binding_info
       _(builder.object_class_struct).must_equal GObject::ObjectClass
     end
+
+    it "returns a valid class for disguised type classes" do
+      binding_info = get_introspection_data "Regress", "FooBuffer"
+      builder = GirFFI::Builders::ObjectBuilder.new binding_info
+
+      _(builder.object_class_struct.name).must_equal "Regress::FooBufferClass"
+    end
   end
 
   describe "for a struct without defined fields" do

--- a/test/gir_ffi/builders/struct_builder_test.rb
+++ b/test/gir_ffi/builders/struct_builder_test.rb
@@ -64,16 +64,10 @@ describe GirFFI::Builders::StructBuilder do
       _(builder.superclass).must_equal GirFFI::BoxedBase
     end
 
-    it "returns the GObject parent class for a type class" do
+    it "raises an error for a type class" do
       info = get_introspection_data "GIMarshallingTests", "SubSubObjectClass"
       builder = GirFFI::Builders::StructBuilder.new info
-      _(builder.superclass).must_equal GIMarshallingTests::SubObjectClass
-    end
-
-    it "returns ObjectClass for InitiallyUnownedClass" do
-      info = get_introspection_data "GObject", "InitiallyUnownedClass"
-      builder = GirFFI::Builders::StructBuilder.new info
-      _(builder.superclass).must_equal GObject::ObjectClass
+      _(proc { builder.superclass }).must_raise RuntimeError
     end
   end
 

--- a/test/gir_ffi/object_base_test.rb
+++ b/test/gir_ffi/object_base_test.rb
@@ -3,6 +3,7 @@
 require "gir_ffi_test_helper"
 
 GirFFI.setup :Regress
+GirFFI.setup :GIMarshallingTests
 
 describe GirFFI::ObjectBase do
   let(:derived_class) { Class.new GirFFI::ObjectBase }


### PR DESCRIPTION
Sometimes the gtype struct (object class struct) for a given class is 'disguised' in the GIR. This means it has no field definitions and therefore the struct's superclass cannot be found by looking at its first field.

This changes the way gtype structs are build, so the class' superclass' gtype struct is injected as the gtype struct's superclass.

So, given a class Foo with superclass Bar, to build gtype struct FooClass, we look at Foo's superclass, Bar, and ask for its gtype struct, BarClass, and inject that when building FooClass.