### PR TITLE
Handle the case where vfunc object arguments are null

### DIFF
--- a/lib/gir_ffi/builders/callback_argument_builder.rb
+++ b/lib/gir_ffi/builders/callback_argument_builder.rb
@@ -19,6 +19,8 @@ module GirFFI
         false
       end
 
+      # All arguments to the argument mapper must always be provided. They may
+      # be nil, though.
       def allow_none?
         false
       end

--- a/lib/gir_ffi/builders/vfunc_argument_builder.rb
+++ b/lib/gir_ffi/builders/vfunc_argument_builder.rb
@@ -9,7 +9,7 @@ module GirFFI
     class VFuncArgumentBuilder < CallbackArgumentBuilder
       def pre_conversion
         if ingoing_ref_needed?
-          super + ["#{pre_converted_name}.ref"]
+          super + ["#{pre_converted_name}&.ref"]
         else
           super
         end

--- a/test/gir_ffi/builders/vfunc_argument_builder_test.rb
+++ b/test/gir_ffi/builders/vfunc_argument_builder_test.rb
@@ -29,7 +29,7 @@ describe GirFFI::Builders::VFuncArgumentBuilder do
     let(:arg_info) { vfunc_info.args[0] }
 
     it "has the correct value for #pre_conversion" do
-      _(builder.pre_conversion).must_equal ["_v1 = GObject::Object.wrap(object)", "_v1.ref"]
+      _(builder.pre_conversion).must_equal ["_v1 = GObject::Object.wrap(object)", "_v1&.ref"]
     end
 
     it "has the correct value for #post_conversion" do

--- a/test/gir_ffi/builders/vfunc_builder_test.rb
+++ b/test/gir_ffi/builders/vfunc_builder_test.rb
@@ -183,7 +183,7 @@ describe GirFFI::Builders::VFuncBuilder do
           def self.call_with_argument_mapping(_proc, _instance, object)
             _v1 = GIMarshallingTests::Object.wrap(_instance)
             _v2 = GObject::Object.wrap(object)
-            _v2.ref
+            _v2&.ref
             _proc.call(_v1, _v2)
           end
         CODE


### PR DESCRIPTION
Object arguments to virtual functions can be null pointers, which means they become `nil` when reified. Call `#ref` safely on them to avoid problems in this case.