### PR TITLE
Remove save_module from tests

### DIFF
--- a/features/conflicting_modules.feature
+++ b/features/conflicting_modules.feature
@@ -10,7 +10,7 @@ Feature: Conflicting modules
 
       puts 'do not print me'
       """
-    And I run `ruby conflict.rb`
+    When I run `ruby conflict.rb`
     Then the output should contain "already defined"
     And the output should not contain "do not print me"
     And the exit status should be 1
@@ -25,7 +25,7 @@ Feature: Conflicting modules
 
       puts 'do not print me'
       """
-    And I run `ruby conflict.rb`
+    When I run `ruby conflict.rb`
     Then the output should contain "already defined"
     And the output should not contain "do not print me"
     And the exit status should be 1
@@ -42,7 +42,7 @@ Feature: Conflicting modules
 
       puts 'do not print me'
       """
-    And I run `ruby conflict.rb`
+    When I run `ruby conflict.rb`
     Then the output should contain "already defined"
     And the output should not contain "do not print me"
     And the exit status should be 1

--- a/features/loading_dependencies.feature
+++ b/features/loading_dependencies.feature
@@ -10,7 +10,7 @@ Feature: Loading dependencies
       GirFFI.setup :Gtk
       puts "Atk exists after: #{Object.const_defined?(:Atk)}"
       """
-    And I run `ruby dependencies.rb`
+    When I run `ruby dependencies.rb`
     Then the output should contain exactly:
       """
       Atk exists before: false

--- a/features/loading_dependencies.feature
+++ b/features/loading_dependencies.feature
@@ -1,0 +1,18 @@
+Feature: Loading dependencies
+  Setting up a module will set up its dependencies as well.
+
+  Scenario: Setting up a module sets up its dependencies as well
+    Given a file named "dependencies.rb" with:
+      """
+      require 'gir_ffi'
+
+      puts "Atk exists before: #{Object.const_defined?(:Atk)}"
+      GirFFI.setup :Gtk
+      puts "Atk exists after: #{Object.const_defined?(:Atk)}"
+      """
+    And I run `ruby dependencies.rb`
+    Then the output should contain exactly:
+      """
+      Atk exists before: false
+      Atk exists after: true
+      """

--- a/features/stubbing_and_calling_methods.feature
+++ b/features/stubbing_and_calling_methods.feature
@@ -1,0 +1,22 @@
+Feature: Stubbing and calling methods
+  Methods are stubbed on the defining class, and set up when called
+
+  Scenario: Setting up a struct class
+    Given a file named "test.rb" with:
+      """
+      require "gir_ffi"
+      GirFFI.setup :Gtk, "3.0"
+      puts "Before: BindingSet exists: #{Gtk.const_defined? :BindingSet}"
+      Gtk.load_class :BindingSet
+      puts "After: BindingSet exists: #{Gtk.const_defined? :BindingSet}"
+      struct = Gtk::BindingSet
+      result = struct.instance_methods.include? :activate
+      puts "Result: #{result}"
+      """
+    When I run `ruby test.rb`
+    Then the output should contain exactly:
+      """
+      Before: BindingSet exists: false
+      After: BindingSet exists: true
+      Result: true
+      """

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -22,35 +22,27 @@ describe GirFFI::Builder do
       _(result.message).must_equal "The module Array was already defined elsewhere"
     end
 
-    describe "building a module for the first time" do
-      before do
-        save_module :Regress
-        GirFFI::Builder.build_module "Regress"
-      end
-
-      it "creates a Lib module ready to attach functions from the shared library" do
-        gir = GObjectIntrospection::IRepository.default
-        expected = [gir.shared_library("Regress")]
-        assert_equal expected, Regress::Lib.ffi_libraries.map(&:name)
-      end
-
-      after do
-        restore_module :Regress
-      end
+    it "creates a Lib module ready to attach functions from the shared library" do
+      # Regress has already been build by GirFFI.setup, which will have done
+      # something like:
+      #
+      #     GirFFI::Builder.build_module "Regress"
+      #
+      gir = GObjectIntrospection::IRepository.default
+      expected = [gir.shared_library("Regress")]
+      assert_equal expected, Regress::Lib.ffi_libraries.map(&:name)
     end
 
-    describe "building a module that already exists" do
-      it "does not replace the existing module" do
-        oldmodule = Regress
-        GirFFI::Builder.build_module "Regress"
-        assert_equal oldmodule, Regress
-      end
+    it "does not replace an existing module" do
+      oldmodule = Regress
+      GirFFI::Builder.build_module "Regress"
+      assert_equal oldmodule, Regress
+    end
 
-      it "does not replace the existing Lib module" do
-        oldmodule = Regress::Lib
-        GirFFI::Builder.build_module "Regress"
-        assert_equal oldmodule, Regress::Lib
-      end
+    it "does not replace the an existing module's Lib module" do
+      oldmodule = Regress::Lib
+      GirFFI::Builder.build_module "Regress"
+      assert_equal oldmodule, Regress::Lib
     end
 
     it "passes the version on to ModuleBuilder" do

--- a/test/gir_ffi/builders/struct_builder_test.rb
+++ b/test/gir_ffi/builders/struct_builder_test.rb
@@ -70,21 +70,4 @@ describe GirFFI::Builders::StructBuilder do
       _(proc { builder.superclass }).must_raise RuntimeError
     end
   end
-
-  describe "#setup_class" do
-    before do
-      save_module :Regress
-    end
-
-    it "stubs the structs methods" do
-      info = get_introspection_data "Regress", "TestStructA"
-      builder = GirFFI::Builders::StructBuilder.new info
-      builder.setup_class
-      assert_defines_instance_method Regress::TestStructA, :clone
-    end
-
-    after do
-      restore_module :Regress
-    end
-  end
 end

--- a/test/gir_ffi/core_test.rb
+++ b/test/gir_ffi/core_test.rb
@@ -17,16 +17,6 @@ describe GirFFI::Core do
     GirFFI.setup :xlib
   end
 
-  it "sets up dependencies" do
-    save_module :Utility
-    save_module :Regress
-    refute Object.const_defined?(:Utility)
-    GirFFI.setup :Regress
-    assert Object.const_defined?(:Utility)
-    restore_module :Regress
-    restore_module :Utility
-  end
-
   describe ".setup" do
     it "passes the desired version down to the module builder" do
       expect(GirFFI::Builder).to receive(:build_module).with("Regress", "0.1")

--- a/test/gir_ffi_test_helper.rb
+++ b/test/gir_ffi_test_helper.rb
@@ -13,24 +13,6 @@ class Sequence
 end
 
 module GirFFITestExtensions
-  SAVED_MODULES = {}
-
-  def save_module(name)
-    return unless Object.const_defined? name
-
-    puts "Saving #{name} over existing" if SAVED_MODULES.key? name
-    SAVED_MODULES[name] = Object.const_get name
-    Object.send(:remove_const, name)
-  end
-
-  def restore_module(name)
-    Object.send(:remove_const, name) if Object.const_defined? name
-    return unless SAVED_MODULES.key? name
-
-    Object.const_set name, SAVED_MODULES[name]
-    SAVED_MODULES.delete name
-  end
-
   def object_ref_count(ptr)
     GObject::Object::Struct.new(ptr.to_ptr)[:ref_count]
   end

--- a/test/integration/derived_classes_test.rb
+++ b/test/integration/derived_classes_test.rb
@@ -3,15 +3,11 @@
 require "gir_ffi_test_helper"
 
 GirFFI.setup :Regress
+GirFFI.setup :GIMarshallingTests
 
 # Tests deriving Ruby classes from GObject classes.
 describe "For derived classes" do
   describe "setting up methods when first called" do
-    before do
-      save_module :GIMarshallingTests
-      GirFFI.setup :GIMarshallingTests
-    end
-
     describe "when an interface is mixed in" do
       before do
         @klass = Class.new GIMarshallingTests::OverridesObject
@@ -27,10 +23,6 @@ describe "For derived classes" do
         result = obj.method
         _(result).must_equal 42
       end
-    end
-
-    after do
-      restore_module :GIMarshallingTests
     end
   end
 

--- a/test/integration/method_lookup_test.rb
+++ b/test/integration/method_lookup_test.rb
@@ -2,13 +2,10 @@
 
 require "gir_ffi_test_helper"
 
+GirFFI.setup :Regress
+
 # Tests how methods are looked up and generated on first use.
 describe "Looking up methods" do
-  before do
-    save_module :Regress
-    GirFFI.setup :Regress
-  end
-
   describe "an instance method" do
     it "is found from a subclass" do
       assert_defines_instance_method Regress::TestObj, :forced_method
@@ -26,9 +23,5 @@ describe "Looking up methods" do
 
       Regress::TestSubObj.static_method 42
     end
-  end
-
-  after do
-    restore_module :Regress
   end
 end


### PR DESCRIPTION
Remove the hacky removal and restoration of generated modules from the test suite. Removing defined modules and classes leads to all kinds of side effects that potentially disturb the behavior of the system.