### PR TITLE
Use prepend for overrides

### DIFF
--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -92,7 +92,6 @@ module GObject
     attach_function :g_object_unref, [:pointer], :pointer
 
     attach_function :g_value_copy, [:pointer, :pointer], :void
-    attach_function :g_value_init, [:pointer, :size_t], :pointer
     attach_function :g_value_unset, [:pointer], :pointer
 
     attach_function :g_signal_connect_data,

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -131,7 +131,8 @@ module GObject
         raise GirFFI::PropertyNotFoundError.new(property_name, self.class)
     end
 
-    module PropertyOverrides
+    # Overrides for GObject, GObject's generic base class.
+    module Overrides
       # @deprecated
       def get_property_extended(property_name)
         get_property(property_name)
@@ -202,6 +203,6 @@ module GObject
       end
     end
 
-    prepend PropertyOverrides
+    prepend Overrides
   end
 end

--- a/lib/ffi-gobject/value.rb
+++ b/lib/ffi-gobject/value.rb
@@ -49,37 +49,6 @@ module GObject
       TYPE_VARIANT   => [:get_variant,        :set_variant]
     }.freeze
 
-    def set_value(val)
-      send set_method, val
-    end
-
-    alias value= set_value
-
-    def current_gtype
-      struct[:g_type]
-    end
-
-    def current_fundamental_type
-      GObject.type_fundamental current_gtype
-    end
-
-    def current_gtype_name
-      GObject.type_name current_gtype
-    end
-
-    def get_value
-      value = get_value_plain
-      if current_fundamental_type == TYPE_BOXED
-        wrap_boxed value
-      else
-        value
-      end
-    end
-
-    def get_value_plain
-      send get_method
-    end
-
     # TODO: Give more generic name
     def self.wrap_ruby_value(val)
       new.tap { |gv| gv.__send__ :set_ruby_value, val }
@@ -114,16 +83,7 @@ module GObject
       Lib.g_value_copy value, target unless value.uninitialized?
     end
 
-    def uninitialized?
-      current_gtype == TYPE_INVALID
-    end
-
     private
-
-    def set_ruby_value(val)
-      init_for_ruby_value val if uninitialized?
-      set_value val
-    end
 
     CLASS_TO_GTYPE_MAP = {
       NilClass   => TYPE_INVALID,
@@ -133,85 +93,127 @@ module GObject
       String     => TYPE_STRING
     }.freeze
 
-    def init_for_ruby_value(val)
-      return init val.class.gtype if val.class.respond_to? :gtype
-
-      CLASS_TO_GTYPE_MAP.each do |klass, type|
-        return init type if val.is_a? klass
-      end
-      raise "Can't handle #{val.class}"
-    end
-
-    def set_none(_val); end
-
-    def get_none; end
-
-    def set_instance_enhanced(val)
-      check_type_compatibility val if val
-      set_instance val
-    end
-
-    def set_enum_enhanced(val)
-      val = current_gtype_class.to_native(val, nil)
-      set_enum val
-    end
-
-    def get_enum_enhanced
-      current_gtype_class.wrap(get_enum)
-    end
-
-    def set_flags_enhanced(val)
-      val = current_gtype_class.to_native(val, nil)
-      set_flags val
-    end
-
-    def get_flags_enhanced
-      current_gtype_class.wrap(get_flags)
-    end
-
-    def current_gtype_class
-      GirFFI::Builder.build_by_gtype(current_gtype)
-    end
-
-    def check_type_compatibility(val)
-      if GObject::Value.type_compatible(GObject.type_from_instance(val), current_gtype)
-        return
-      end
-
-      raise ArgumentError, "#{val.class} is incompatible with #{current_gtype_name}"
-    end
-
-    def wrap_boxed(boxed)
-      case current_gtype
-      when TYPE_STRV
-        GLib::Strv.wrap boxed
-      when TYPE_HASH_TABLE
-        GLib::HashTable.wrap [:gpointer, :gpointer], boxed
-      when TYPE_ARRAY
-        GLib::Array.wrap nil, boxed
-      else
-        current_gtype_class.wrap(boxed) unless boxed.null?
-      end
-    end
-
-    def get_method
-      method_map_entry.first
-    end
-
-    def set_method
-      method_map_entry.last
-    end
-
-    def method_map_entry
-      METHOD_MAP[current_gtype] || METHOD_MAP[current_fundamental_type] ||
-        raise("No method map entry for '#{current_gtype_name}'")
-    end
-
     # Overrides for existing Value methods
     module Overrides
+      def set_value(val)
+        send set_method, val
+      end
+
+      alias value= set_value
+
+      def current_gtype
+        struct[:g_type]
+      end
+
+      def current_fundamental_type
+        GObject.type_fundamental current_gtype
+      end
+
+      def current_gtype_name
+        GObject.type_name current_gtype
+      end
+
+      def get_value
+        value = get_value_plain
+        if current_fundamental_type == TYPE_BOXED
+          wrap_boxed value
+        else
+          value
+        end
+      end
+
+      def get_value_plain
+        send get_method
+      end
+
+      def uninitialized?
+        current_gtype == TYPE_INVALID
+      end
+
       def init(type)
         Lib.g_value_init self, type unless [TYPE_NONE, TYPE_INVALID].include? type
         self
+      end
+
+      private
+
+      def set_ruby_value(val)
+        init_for_ruby_value val if uninitialized?
+        set_value val
+      end
+
+      def init_for_ruby_value(val)
+        return init val.class.gtype if val.class.respond_to? :gtype
+
+        CLASS_TO_GTYPE_MAP.each do |klass, type|
+          return init type if val.is_a? klass
+        end
+        raise "Can't handle #{val.class}"
+      end
+
+      def set_none(_val); end
+
+      def get_none; end
+
+      def set_instance_enhanced(val)
+        check_type_compatibility val if val
+        set_instance val
+      end
+
+      def set_enum_enhanced(val)
+        val = current_gtype_class.to_native(val, nil)
+        set_enum val
+      end
+
+      def get_enum_enhanced
+        current_gtype_class.wrap(get_enum)
+      end
+
+      def set_flags_enhanced(val)
+        val = current_gtype_class.to_native(val, nil)
+        set_flags val
+      end
+
+      def get_flags_enhanced
+        current_gtype_class.wrap(get_flags)
+      end
+
+      def current_gtype_class
+        GirFFI::Builder.build_by_gtype(current_gtype)
+      end
+
+      def check_type_compatibility(val)
+        if GObject::Value.type_compatible(GObject.type_from_instance(val), current_gtype)
+          return
+        end
+
+        raise ArgumentError, "#{val.class} is incompatible with #{current_gtype_name}"
+      end
+
+      def wrap_boxed(boxed)
+        case current_gtype
+        when TYPE_STRV
+          GLib::Strv.wrap boxed
+        when TYPE_HASH_TABLE
+          GLib::HashTable.wrap [:gpointer, :gpointer], boxed
+        when TYPE_ARRAY
+          GLib::Array.wrap nil, boxed
+        else
+          current_gtype_class.wrap(boxed) unless boxed.null?
+        end
+      end
+
+      def get_method
+        method_map_entry.first
+      end
+
+      def set_method
+        method_map_entry.last
+      end
+
+      def method_map_entry
+        METHOD_MAP[current_gtype] || METHOD_MAP[current_fundamental_type] ||
+          raise("No method map entry for '#{current_gtype_name}'")
       end
     end
 

--- a/lib/ffi-gobject/value.rb
+++ b/lib/ffi-gobject/value.rb
@@ -207,6 +207,7 @@ module GObject
         raise("No method map entry for '#{current_gtype_name}'")
     end
 
+    # Overrides for existing Value methods
     module Overrides
       def init(type)
         Lib.g_value_init self, type unless [TYPE_NONE, TYPE_INVALID].include? type

--- a/lib/ffi-gobject/value.rb
+++ b/lib/ffi-gobject/value.rb
@@ -5,17 +5,12 @@ GObject.load_class :Value
 module GObject
   # Overrides for GValue, GObject's generic value container structure.
   class Value
-    remove_method :init
+    setup_instance_method! :init
 
     def initialize
       super
       struct.owned = true
       to_ptr.autorelease = nil
-    end
-
-    def init(type)
-      Lib.g_value_init self, type unless [TYPE_NONE, TYPE_INVALID].include? type
-      self
     end
 
     def self.make_finalizer(struct)
@@ -211,5 +206,14 @@ module GObject
       METHOD_MAP[current_gtype] || METHOD_MAP[current_fundamental_type] ||
         raise("No method map entry for '#{current_gtype_name}'")
     end
+
+    module Overrides
+      def init(type)
+        Lib.g_value_init self, type unless [TYPE_NONE, TYPE_INVALID].include? type
+        self
+      end
+    end
+
+    prepend Overrides
   end
 end


### PR DESCRIPTION
Replace overrides using alias chaining with Module.prepend. This is an ongoing change, there's more alias chaining going on than fixed in this pull request.