### PR TITLE
Give pending finalizers a chance to run before main finalizer test

### DIFF
--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -106,6 +106,9 @@ describe GObject::Object do
     it "lowers the reference count" do
       skip "cannot be reliably tested on JRuby" if jruby?
 
+      # Make sure other pending finalizers have been run
+      GC.start
+
       ptr = GObject::Object.new.to_ptr
       _(object_ref_count(ptr)).must_equal 1
 


### PR DESCRIPTION
This avoids a rare problem where the pointer that is being tested is already overwritten with garbage before we can read the final reference count.

In the parent commit (1b017bee), this problem can be triggered by running:

```bash
TEST_OPTS='--seed=52965' bundle exec rake test:all
```