### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 require:
   - rubocop-performance
+  - rubocop-packaging
 
 AllCops:
   Exclude:

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     provide enough or correct information to create sane bindings, overrides may be created.
   DESC
 
-  s.files = Dir["{docs,examples,lib}/**/*", "COPYING.LIB"]
+  s.files = Rake::FileList["{docs,examples,lib}/**/*", "COPYING.LIB"].exclude(*File.read('.gitignore').split)
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["DESIGN.md", "Changelog.md", "README.md", "TODO.md"]
 

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -22,12 +22,7 @@ Gem::Specification.new do |s|
     provide enough or correct information to create sane bindings, overrides may be created.
   DESC
 
-  s.files = Dir["{lib,test,tasks,examples}/**/*",
-                "*.md",
-                "Gemfile",
-                "Rakefile",
-                "COPYING.LIB"] & `git ls-files -z`.split("\0")
-
+  s.files = Dir["{docs,examples,lib}/**/*", "COPYING.LIB"]
   s.rdoc_options = ["--main", "README.md"]
   s.extra_rdoc_files = ["DESIGN.md", "Changelog.md", "README.md", "TODO.md"]
 
@@ -39,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rake", ["~> 13.0"])
   s.add_development_dependency("rexml", ["~> 3.0"])
   s.add_development_dependency("rspec-mocks", ["~> 3.5"])
+  s.add_development_dependency("rubocop-packaging", ["~> 0.1.1"])
   s.add_development_dependency("simplecov", ["~> 0.18.0"])
 
   s.require_paths = ["lib"]

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.join(File.dirname(__FILE__), "lib/gir_ffi/version.rb")
+require "rake/file_list"
 
 Gem::Specification.new do |s|
   s.name = "gir_ffi"


### PR DESCRIPTION
Hi @mvz,

Thanks for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end-users and not other things which are not needed by them! :rocket: 

Also, added `rubocop-packaging` as a development_dependency which will ensure the best practices.
Here's what it shows us:

```
➜  gir_ffi git:(master) rubocop --only Packaging

Inspecting 302 files
......C..............................................................................................
.....................................................................................................
.....................................................................................................

Offenses:

gir_ffi.gemspec:29:34: C: Packaging/GemspecGit: Avoid using git to produce lists of files. Downstreams
often need to build your package in an environment that does not have git (on purpose). Use some pure
Ruby alternative, like Dir or Dir.glob.
                "COPYING.LIB"] & `git ls-files -z`.split("\0")
                                 ^^^^^^^^^^^^^^^^^

302 files inspected, 1 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>