### PR TITLE
Improve List and SList methods

### DIFF
--- a/lib/ffi-glib.rb
+++ b/lib/ffi-glib.rb
@@ -35,6 +35,7 @@ module GLib
     attach_function :g_slist_prepend, [:pointer, :pointer], :pointer
 
     attach_function :g_list_append, [:pointer, :pointer], :pointer
+    attach_function :g_list_prepend, [:pointer, :pointer], :pointer
 
     attach_function :g_hash_table_foreach, [:pointer, HFunc, :pointer], :void
     attach_function :g_hash_table_new, [HashFunc, EqualFunc], :pointer

--- a/lib/ffi-glib.rb
+++ b/lib/ffi-glib.rb
@@ -32,6 +32,7 @@ module GLib
   # Module for attaching functions from the glib library. This module is
   # defined by the call to ModuleBuilder#generate above.
   module Lib
+    attach_function :g_slist_append, [:pointer, :pointer], :pointer
     attach_function :g_slist_prepend, [:pointer, :pointer], :pointer
 
     attach_function :g_list_append, [:pointer, :pointer], :pointer

--- a/lib/ffi-glib.rb
+++ b/lib/ffi-glib.rb
@@ -34,9 +34,11 @@ module GLib
   module Lib
     attach_function :g_slist_append, [:pointer, :pointer], :pointer
     attach_function :g_slist_prepend, [:pointer, :pointer], :pointer
+    attach_function :g_slist_reverse, [:pointer], :pointer
 
     attach_function :g_list_append, [:pointer, :pointer], :pointer
     attach_function :g_list_prepend, [:pointer, :pointer], :pointer
+    attach_function :g_list_reverse, [:pointer], :pointer
 
     attach_function :g_hash_table_foreach, [:pointer, HFunc, :pointer], :void
     attach_function :g_hash_table_new, [HashFunc, EqualFunc], :pointer

--- a/lib/ffi-glib/list.rb
+++ b/lib/ffi-glib/list.rb
@@ -14,8 +14,8 @@ module GLib
     end
 
     def append(data)
-      self.class.wrap(element_type,
-                      Lib.g_list_append(self, element_ptr_for(data)))
+      store_pointer Lib.g_list_append(self, element_ptr_for(data))
+      self
     end
   end
 end

--- a/lib/ffi-glib/list.rb
+++ b/lib/ffi-glib/list.rb
@@ -17,5 +17,10 @@ module GLib
       store_pointer Lib.g_list_append(self, element_ptr_for(data))
       self
     end
+
+    def prepend(data)
+      store_pointer Lib.g_list_prepend(self, element_ptr_for(data))
+      self
+    end
   end
 end

--- a/lib/ffi-glib/list.rb
+++ b/lib/ffi-glib/list.rb
@@ -10,7 +10,7 @@ module GLib
     include ListMethods
 
     def self.from_enumerable(type, arr)
-      arr.reduce(new(type)) { |lst, val| lst.append val }
+      arr.reverse.reduce(new(type)) { |lst, val| lst.prepend val }
     end
 
     def append(data)

--- a/lib/ffi-glib/list.rb
+++ b/lib/ffi-glib/list.rb
@@ -9,10 +9,6 @@ module GLib
   class List
     include ListMethods
 
-    def self.from_enumerable(type, arr)
-      arr.reduce(new(type)) { |lst, val| lst.prepend val }.reverse
-    end
-
     def append(data)
       store_pointer Lib.g_list_append(self, element_ptr_for(data))
       self

--- a/lib/ffi-glib/list.rb
+++ b/lib/ffi-glib/list.rb
@@ -10,7 +10,7 @@ module GLib
     include ListMethods
 
     def self.from_enumerable(type, arr)
-      arr.reverse.reduce(new(type)) { |lst, val| lst.prepend val }
+      arr.reduce(new(type)) { |lst, val| lst.prepend val }.reverse
     end
 
     def append(data)
@@ -20,6 +20,11 @@ module GLib
 
     def prepend(data)
       store_pointer Lib.g_list_prepend(self, element_ptr_for(data))
+      self
+    end
+
+    def reverse
+      store_pointer Lib.g_list_reverse(self)
       self
     end
   end

--- a/lib/ffi-glib/list_methods.rb
+++ b/lib/ffi-glib/list_methods.rb
@@ -36,10 +36,12 @@ module GLib
     end
 
     def tail
+      return nil if struct.null?
       self.class.wrap(element_type, struct[:next])
     end
 
     def head
+      return nil if struct.null?
       GirFFI::ArgHelper.cast_from_pointer(element_type, struct[:data])
     end
 

--- a/lib/ffi-glib/list_methods.rb
+++ b/lib/ffi-glib/list_methods.rb
@@ -14,6 +14,7 @@ module GLib
       replace_method base, :data, :head
 
       base.extend ContainerClassMethods
+      base.extend ClassMethods
     end
 
     def self.replace_method(base, old, new)
@@ -70,6 +71,12 @@ module GLib
 
     def element_ptr_for(data)
       GirFFI::InPointer.from(element_type, data)
+    end
+
+    module ClassMethods
+      def from_enumerable(type, arr)
+        arr.reduce(new(type)) { |lst, val| lst.prepend val }.reverse
+      end
     end
   end
 end

--- a/lib/ffi-glib/s_list.rb
+++ b/lib/ffi-glib/s_list.rb
@@ -14,8 +14,8 @@ module GLib
     end
 
     def prepend(data)
-      self.class.wrap(element_type,
-                      Lib.g_slist_prepend(self, element_ptr_for(data)))
+      store_pointer Lib.g_slist_prepend(self, element_ptr_for(data))
+      self
     end
   end
 end

--- a/lib/ffi-glib/s_list.rb
+++ b/lib/ffi-glib/s_list.rb
@@ -10,7 +10,7 @@ module GLib
     include ListMethods
 
     def self.from_enumerable(type, arr)
-      arr.reverse.reduce(new(type)) { |lst, val| lst.prepend val }
+      arr.reduce(new(type)) { |lst, val| lst.prepend val }.reverse
     end
 
     def append(data)
@@ -20,6 +20,11 @@ module GLib
 
     def prepend(data)
       store_pointer Lib.g_slist_prepend(self, element_ptr_for(data))
+      self
+    end
+
+    def reverse
+      store_pointer Lib.g_slist_reverse(self)
       self
     end
   end

--- a/lib/ffi-glib/s_list.rb
+++ b/lib/ffi-glib/s_list.rb
@@ -13,6 +13,11 @@ module GLib
       arr.reverse.reduce(new(type)) { |lst, val| lst.prepend val }
     end
 
+    def append(data)
+      store_pointer Lib.g_slist_append(self, element_ptr_for(data))
+      self
+    end
+
     def prepend(data)
       store_pointer Lib.g_slist_prepend(self, element_ptr_for(data))
       self

--- a/lib/ffi-glib/s_list.rb
+++ b/lib/ffi-glib/s_list.rb
@@ -9,10 +9,6 @@ module GLib
   class SList
     include ListMethods
 
-    def self.from_enumerable(type, arr)
-      arr.reduce(new(type)) { |lst, val| lst.prepend val }.reverse
-    end
-
     def append(data)
       store_pointer Lib.g_slist_append(self, element_ptr_for(data))
       self

--- a/test/ffi-glib/list_test.rb
+++ b/test/ffi-glib/list_test.rb
@@ -82,5 +82,11 @@ describe GLib::List do
 
       _(list).wont_be :==, other
     end
+
+    it "returns true when comparing an empty list with an empty array" do
+      list = GLib::List.from :gint32, []
+
+      _(list).must_be :==, []
+    end
   end
 end

--- a/test/ffi-glib/list_test.rb
+++ b/test/ffi-glib/list_test.rb
@@ -9,27 +9,30 @@ describe GLib::List do
   end
 
   describe "#append" do
-    it "appends integer values" do
+    it "updates the list object itself" do
       lst = GLib::List.new :gint32
       res = lst.append 1
-      assert_equal 1, res.data
+      _(res.to_ptr).must_equal lst.to_ptr
+    end
+
+    it "appends integer values" do
+      lst = GLib::List.new :gint32
+      lst.append 1
+      _(lst.data).must_equal 1
     end
 
     it "appends string values" do
       lst = GLib::List.new :utf8
-      res = lst.append "bla"
-      assert_equal "bla", res.data
+      lst.append "bla"
+      _(lst.data).must_equal "bla"
     end
 
     it "appends multiple values into a single list" do
       lst = GLib::List.new :gint32
+      lst.append 1
+      lst.append 2
 
-      lst = lst.append 1
-      lst = lst.append 2
-
-      assert_equal 1, lst.data
-      nxt = lst.next
-      assert_equal 2, nxt.data
+      _(lst).must_be :==, [1, 2]
     end
   end
 

--- a/test/ffi-glib/list_test.rb
+++ b/test/ffi-glib/list_test.rb
@@ -85,6 +85,11 @@ describe GLib::List do
       refute lst2.equal? lst
       _(lst2.to_a).must_equal lst.to_a
     end
+
+    it "creates a GList from a Ruby range" do
+      lst = GLib::List.from :gint32, (1..3)
+      assert_equal [1, 2, 3], lst.to_a
+    end
   end
 
   describe "#==" do

--- a/test/ffi-glib/list_test.rb
+++ b/test/ffi-glib/list_test.rb
@@ -36,6 +36,34 @@ describe GLib::List do
     end
   end
 
+  describe "#prepend" do
+    it "updates the list object itself" do
+      lst = GLib::List.new :gint32
+      res = lst.prepend 1
+      _(res.to_ptr).must_equal lst.to_ptr
+    end
+
+    it "prepends integer values" do
+      lst = GLib::List.new :gint32
+      lst.prepend 1
+      _(lst.data).must_equal 1
+    end
+
+    it "prepends string values" do
+      lst = GLib::List.new :utf8
+      lst.prepend "bla"
+      _(lst.data).must_equal "bla"
+    end
+
+    it "prepends multiple values into a single list" do
+      lst = GLib::List.new :gint32
+      lst.prepend 1
+      lst.prepend 2
+
+      _(lst).must_be :==, [2, 1]
+    end
+  end
+
   describe "::from" do
     it "creates a GList from a Ruby array" do
       lst = GLib::List.from :gint32, [3, 2, 1]

--- a/test/ffi-glib/s_list_test.rb
+++ b/test/ffi-glib/s_list_test.rb
@@ -76,6 +76,11 @@ describe GLib::SList do
       lst2 = GLib::SList.from :gint32, lst
       assert_equal lst, lst2
     end
+
+    it "creates a GSList from a Ruby range" do
+      lst = GLib::SList.from :gint32, (1..3)
+      assert_equal [1, 2, 3], lst.to_a
+    end
   end
 
   describe "#==" do

--- a/test/ffi-glib/s_list_test.rb
+++ b/test/ffi-glib/s_list_test.rb
@@ -8,6 +8,34 @@ describe GLib::SList do
     assert_equal :gint32, arr.element_type
   end
 
+  describe "#append" do
+    it "updates the list object itself" do
+      lst = GLib::SList.new :gint32
+      res = lst.append 1
+      _(res.to_ptr).must_equal lst.to_ptr
+    end
+
+    it "appends integer values" do
+      lst = GLib::SList.new :gint32
+      lst.append 1
+      _(lst.data).must_equal 1
+    end
+
+    it "appends string values" do
+      lst = GLib::SList.new :utf8
+      lst.append "bla"
+      _(lst.data).must_equal "bla"
+    end
+
+    it "appends multiple values into a single list" do
+      lst = GLib::SList.new :gint32
+      lst.append 1
+      lst.append 2
+
+      _(lst).must_be :==, [1, 2]
+    end
+  end
+
   describe "#prepend" do
     it "updates the list object itself" do
       lst = GLib::SList.new :gint32

--- a/test/ffi-glib/s_list_test.rb
+++ b/test/ffi-glib/s_list_test.rb
@@ -9,27 +9,31 @@ describe GLib::SList do
   end
 
   describe "#prepend" do
-    it "prepends integer values" do
+    it "updates the list object itself" do
       lst = GLib::SList.new :gint32
       res = lst.prepend 1
-      assert_equal 1, res.data
+      _(res.to_ptr).must_equal lst.to_ptr
+    end
+
+    it "prepends integer values" do
+      lst = GLib::SList.new :gint32
+      lst.prepend 1
+      _(lst).must_be :==, [1]
     end
 
     it "prepends string values" do
       lst = GLib::SList.new :utf8
-      res = lst.prepend "bla"
-      assert_equal "bla", res.data
+      lst.prepend "bla"
+      _(lst).must_be :==, ["bla"]
     end
 
     it "prepends multiple values into a single list" do
       lst = GLib::SList.new :gint32
 
-      res = lst.prepend 1
-      res2 = res.prepend 2
+      lst.prepend 1
+      lst.prepend 2
 
-      assert_equal 2, res2.data
-      assert_equal 1, res.data
-      assert_equal res.to_ptr, res2.next.to_ptr
+      _(lst).must_be :==, [2, 1]
     end
   end
 

--- a/test/ffi-glib/s_list_test.rb
+++ b/test/ffi-glib/s_list_test.rb
@@ -72,5 +72,11 @@ describe GLib::SList do
 
       _(list).wont_be :==, other
     end
+
+    it "returns true when comparing an empty list with an empty array" do
+      list = GLib::SList.from :gint32, []
+
+      _(list).must_be :==, []
+    end
   end
 end


### PR DESCRIPTION
- Make `ListMethods#to_a` work for empty lists
- Make `SList#prepend` update the object itself

  This makes it match the behavior of Array#prepend
- Make `List#append` update the object itself

  This makes it match the behavior of Array#append
- Add override for GLib::List#prepend
- Add override for GLib::SList#append
- Speed up `List#from_enumerable` for large enumerables

  `List#append` traverses the entire list to append an element, while `List#prepend` does not. So it's faster to reverse the given enumerable and use prepend to construct the list.

- Make `.from_enumerable` methods for lists work with all enumerables

  The `#reverse` method is not defined in `Enumerable` so should not be used. Instead, `#reverse_each` could have been used, but it creates a temporary array so is potentially slow. It also causes an infinite loop for infinite ranges, but that is not really relevant since `#reduce` also causes an infinite loop.

- Move `.from_enumerable` into common module