### PR TITLE
Make ByteArray#append return self

### DIFF
--- a/lib/ffi-glib/byte_array.rb
+++ b/lib/ffi-glib/byte_array.rb
@@ -12,7 +12,8 @@ module GLib
     def append(data)
       bytes = GirFFI::InPointer.from_utf8 data
       len = data.bytesize
-      self.class.wrap Lib.g_byte_array_append(to_ptr, bytes, len)
+      Lib.g_byte_array_append(to_ptr, bytes, len)
+      self
     end
 
     def self.from(data)

--- a/test/ffi-glib/byte_array_test.rb
+++ b/test/ffi-glib/byte_array_test.rb
@@ -8,10 +8,18 @@ describe GLib::ByteArray do
     assert_instance_of GLib::ByteArray, ba
   end
 
-  it "allows strings to be appended to it" do
-    ba = GLib::ByteArray.new
-    ba.append "abdc"
-    pass
+  describe "#append" do
+    it "allows strings to be appended" do
+      ba = GLib::ByteArray.new
+      ba.append "abdc"
+      pass
+    end
+
+    it "returns self" do
+      ba = GLib::ByteArray.new
+      result = ba.append "abdc"
+      _(result.object_id).must_equal ba.object_id
+    end
   end
 
   it "has a working #to_string method" do


### PR DESCRIPTION
The `g_byte_array_append` function returns the same pointer as its first argument. Instead of creating a new object, just return self.