### PR TITLE
Clean up several warnings emitted during test runs

### DIFF
--- a/test/ffi-gobject/value_test.rb
+++ b/test/ffi-gobject/value_test.rb
@@ -7,17 +7,10 @@ GirFFI.setup :Gio
 
 describe GObject::Value do
   describe "::Struct" do
-    describe "layout" do
-      let(:layout) { GObject::Value::Struct.layout }
+    let(:struct) { GObject::Value::Struct }
 
-      it "consists of :g_type and :data" do
-        _(layout.members).must_equal [:g_type, :data]
-      end
-
-      it "has an array as its second element" do
-        types = layout.fields.map(&:type)
-        _(types[1].class).must_equal FFI::Type::Array
-      end
+    it "has the members :g_type and :data" do
+      _(struct.members).must_equal [:g_type, :data]
     end
   end
 

--- a/test/ffi-gobject_test.rb
+++ b/test/ffi-gobject_test.rb
@@ -118,16 +118,15 @@ describe GObject do
         @a = nil
         @b = 2
 
-        o = Regress::TestSubObj.new
+        obj = Regress::TestSubObj.new
         sb = Regress::TestSimpleBoxedA.new
         sb.some_int = 23
 
-        GObject.signal_connect(o, "test-with-static-scope-arg", 2) \
-          do |_instance, object, user_data|
-          @a = user_data
-          @b = object
+        GObject.signal_connect(obj, "test-with-static-scope-arg", 2) do |_i, o, u|
+          @a = u
+          @b = o
         end
-        GObject.signal_emit o, "test-with-static-scope-arg", sb
+        GObject.signal_emit obj, "test-with-static-scope-arg", sb
       end
 
       it "passes on the user data argument" do

--- a/test/gir_ffi/builders/signal_closure_builder_test.rb
+++ b/test/gir_ffi/builders/signal_closure_builder_test.rb
@@ -139,8 +139,7 @@ describe GirFFI::Builders::SignalClosureBuilder do
         get_signal_introspection_data "Regress", "AnnotationObject", "attribute-signal"
       end
 
-      it "returns a mapping method that passes the string result to return_value directly" \
-        do
+      it "returns a mapping method that passes the result to return_value directly" do
         expected = <<~CODE
           def self.marshaller(closure, return_value, param_values, _invocation_hint, _marshal_data)
             _instance, arg1, arg2 = param_values.map(&:get_value_plain)


### PR DESCRIPTION
- Fix do/end alignment mismatches
- Avoid calling FFI::Struct.layout in tests