### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, jruby-9.2]
+        ruby: [2.5, 2.6, 2.7, 3.0, jruby-9.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -75,7 +75,13 @@ module GObject
     end
 
     def self.make_finalizer(ptr)
-      proc do
+      proc { finalize ptr }
+    end
+
+    class << self
+      protected
+
+      def finalize(ptr)
         rc = GObject::Object::Struct.new(ptr)[:ref_count]
         if rc == 0
           warn "not unreffing #{name}:#{ptr} (#{rc})"

--- a/lib/ffi-gobject/value.rb
+++ b/lib/ffi-gobject/value.rb
@@ -7,16 +7,6 @@ module GObject
   class Value
     setup_instance_method! :init
 
-    def self.make_finalizer(struct)
-      proc do
-        if struct.owned?
-          ptr = struct.to_ptr
-          Lib.g_value_unset ptr unless struct[:g_type] == TYPE_INVALID
-          GObject.boxed_free gtype, ptr
-        end
-      end
-    end
-
     METHOD_MAP = {
       TYPE_INVALID   => [:get_none,           :set_none],
       # TYPE_NONE is skipped

--- a/lib/ffi-gobject_introspection/i_base_info.rb
+++ b/lib/ffi-gobject_introspection/i_base_info.rb
@@ -4,19 +4,26 @@ module GObjectIntrospection
   # Wraps GIBaseInfo struct, the base \type for all info types.
   # Decendant types will be implemented as needed.
   class IBaseInfo
-    def initialize(ptr, lib = Lib)
+    def initialize(ptr)
       raise ArgumentError, "ptr must not be null" if ptr.null?
 
-      ObjectSpace.define_finalizer self, self.class.make_finalizer(lib, ptr)
+      ObjectSpace.define_finalizer self, self.class.make_finalizer(ptr)
 
       @pointer = ptr
-      @lib = lib
     end
 
     attr_reader :pointer
 
-    def self.make_finalizer(lib, ptr)
-      proc { lib.g_base_info_unref ptr }
+    def self.make_finalizer(ptr)
+      proc { finalize ptr }
+    end
+
+    class << self
+      protected
+
+      def finalize(ptr)
+        Lib.g_base_info_unref ptr
+      end
     end
 
     def to_ptr

--- a/lib/gir_ffi/boxed_base.rb
+++ b/lib/gir_ffi/boxed_base.rb
@@ -6,17 +6,23 @@ module GirFFI
   # Base class for generated classes representing boxed types.
   class BoxedBase < StructLikeBase
     def self.make_finalizer(struct)
-      proc do
-        if struct.owned?
-          struct.owned = nil
-          GObject.boxed_free gtype, struct.to_ptr
-        end
-      end
+      proc { finalize(struct) }
     end
 
     def self.copy(val)
       ptr = GObject.boxed_copy(gtype, val)
       wrap(ptr)
+    end
+
+    class << self
+      protected
+
+      def finalize(struct)
+        struct.owned? or return
+
+        struct.owned = nil
+        GObject.boxed_free gtype, struct.to_ptr
+      end
     end
 
     private

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -104,23 +104,11 @@ describe GObject::Object do
 
   describe "upon garbage collection" do
     it "lowers the reference count" do
-      skip "cannot be reliably tested on JRuby" if jruby?
-
-      # Make sure other pending finalizers have been run
-      GC.start
-
-      ptr = GObject::Object.new.to_ptr
-      _(object_ref_count(ptr)).must_equal 1
-
-      GC.start
-      # Creating a new object is sometimes needed to trigger enough garbage collection.
-      GObject::Object.new
-      sleep 1
-
-      GC.start
-      GC.start
-
-      _(object_ref_count(ptr)).must_equal 0
+      obj = GObject::Object.new
+      GObject::Lib.g_object_ref obj.to_ptr
+      _(object_ref_count(obj)).must_equal 2
+      GObject::Object.send :finalize, obj.to_ptr
+      _(object_ref_count(obj)).must_equal 1
     end
   end
 end

--- a/test/ffi-gobject/value_test.rb
+++ b/test/ffi-gobject/value_test.rb
@@ -362,20 +362,12 @@ describe GObject::Value do
 
   describe "upon garbage collection" do
     it "restores the underlying GValue to its pristine state" do
-      skip "cannot be reliably tested on JRuby" if jruby?
-
       value = GObject::Value.from 42
 
-      # Drop reference to original GObject::Value
-      value = GObject::Value.wrap value.to_ptr
       _(value.current_gtype_name).must_equal "gint"
 
-      GC.start
-      # Creating a new object is sometimes needed to trigger enough garbage collection.
-      GObject::Value.new
-      sleep 1
-      GC.start
-      GC.start
+      struct = value.struct
+      GObject::Value.send :finalize, struct
 
       _(value.current_gtype_name).wont_equal "gint"
     end

--- a/test/gir_ffi/boxed_base_test.rb
+++ b/test/gir_ffi/boxed_base_test.rb
@@ -38,8 +38,6 @@ describe GirFFI::BoxedBase do
 
   describe "upon garbage collection" do
     it "frees and disowns the underlying struct if it is owned" do
-      skip "cannot be reliably tested on JRuby" if jruby?
-
       allow(GObject).to receive(:boxed_free)
       gtype = GIMarshallingTests::BoxedStruct.gtype
 
@@ -50,12 +48,8 @@ describe GirFFI::BoxedBase do
       unowned_struct.owned = false
       unowned_ptr = unowned_struct.to_ptr
 
-      GC.start
-      # Creating a new object is sometimes needed to trigger enough garbage collection.
-      GIMarshallingTests::BoxedStruct.new
-      sleep 1
-      GC.start
-      GC.start
+      GIMarshallingTests::BoxedStruct.send :finalize, owned_struct
+      GIMarshallingTests::BoxedStruct.send :finalize, unowned_struct
 
       expect(GObject).to have_received(:boxed_free).with(gtype, owned_ptr)
       expect(GObject).not_to have_received(:boxed_free).with(gtype, unowned_ptr)


### PR DESCRIPTION
- Simplify finalizer tests by not relying on GC.start
- Run tests on Ruby 3.0 in CI