### PR TITLE
require "set" in callback_base.rb

### DIFF
--- a/lib/gir_ffi/callback_base.rb
+++ b/lib/gir_ffi/callback_base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "gir_ffi/type_base"
+require "set"
 
 module GirFFI
   # Base module for callbacks and vfuncs.


### PR DESCRIPTION
On the Ruby included with Ubuntu 20.04 (`ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-gnu]`), I get this traceback when requiring `gir_ffi` unless I ensure that `set` is required first:

```
Traceback (most recent call last):
        2: from -:1:in `<main>'
/usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- gir_ffi (LoadError)
        24: from -:1:in `<main>'
        23: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:156:in `require'
        22: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `rescue in require'
        21: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:168:in `require'
        20: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi.rb:3:in `<top (required)>'
        19: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        18: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        17: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/core.rb:17:in `<top (required)>'
        16: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        15: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        14: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/arg_helper.rb:4:in `<top (required)>'
        13: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        12: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
        11: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/builder.rb:3:in `<top (required)>'
        10: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         9: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         8: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/builders/type_builder.rb:3:in `<top (required)>'
         7: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         6: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         5: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/builders/callback_builder.rb:5:in `<top (required)>'
         4: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         3: from /usr/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
         2: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/callback_base.rb:5:in `<top (required)>'
         1: from /var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/callback_base.rb:9:in `<module:GirFFI>'
/var/lib/gems/2.7.0/gems/gir_ffi-0.15.5/lib/gir_ffi/callback_base.rb:38:in `<class:CallbackBase>': uninitialized constant GirFFI::CallbackBase::Set (NameError)
```


This PR adds `require "set"` to the file that throws the error.