### PR TITLE
Update rake-manifest and fix manifest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,9 +46,11 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - name: Run tests
-      run: bundle exec rake
+      run: bundle exec rake test:all
+    - name: Run features
+      run: bundle exec rake test:features
 
-  rubocop:
+  lint:
 
     runs-on: ubuntu-latest
 
@@ -61,3 +63,5 @@ jobs:
         bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop -P
+    - name: Check manifest
+      run: bundle exec rake manifest:check

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -2,7 +2,6 @@ docs/Documentation.md
 docs/Subclassing.md
 examples/clutter.rb
 examples/main_loop.rb
-lib/ffi-glib
 lib/ffi-glib.rb
 lib/ffi-glib/array.rb
 lib/ffi-glib/byte_array.rb
@@ -18,7 +17,6 @@ lib/ffi-glib/ptr_array.rb
 lib/ffi-glib/s_list.rb
 lib/ffi-glib/strv.rb
 lib/ffi-glib/variant.rb
-lib/ffi-gobject
 lib/ffi-gobject.rb
 lib/ffi-gobject/closure.rb
 lib/ffi-gobject/initially_unowned.rb
@@ -27,7 +25,6 @@ lib/ffi-gobject/object_class.rb
 lib/ffi-gobject/param_spec.rb
 lib/ffi-gobject/ruby_closure.rb
 lib/ffi-gobject/value.rb
-lib/ffi-gobject_introspection
 lib/ffi-gobject_introspection.rb
 lib/ffi-gobject_introspection/g_error.rb
 lib/ffi-gobject_introspection/gobject_type_init.rb
@@ -54,10 +51,7 @@ lib/ffi-gobject_introspection/i_value_info.rb
 lib/ffi-gobject_introspection/i_vfunc_info.rb
 lib/ffi-gobject_introspection/lib.rb
 lib/ffi-gobject_introspection/strv.rb
-lib/gir_ffi
-lib/gir_ffi-base
 lib/gir_ffi-base.rb
-lib/gir_ffi-base/gobject
 lib/gir_ffi-base/gobject.rb
 lib/gir_ffi-base/gobject/lib.rb
 lib/gir_ffi.rb
@@ -68,7 +62,6 @@ lib/gir_ffi/boolean.rb
 lib/gir_ffi/boxed_base.rb
 lib/gir_ffi/builder.rb
 lib/gir_ffi/builder_helper.rb
-lib/gir_ffi/builders
 lib/gir_ffi/builders/argument_builder.rb
 lib/gir_ffi/builders/argument_builder_collection.rb
 lib/gir_ffi/builders/base_argument_builder.rb
@@ -127,7 +120,6 @@ lib/gir_ffi/enum_base.rb
 lib/gir_ffi/enum_like_base.rb
 lib/gir_ffi/error_argument_info.rb
 lib/gir_ffi/error_type_info.rb
-lib/gir_ffi/ffi_ext
 lib/gir_ffi/ffi_ext.rb
 lib/gir_ffi/ffi_ext/pointer.rb
 lib/gir_ffi/field_argument_info.rb
@@ -135,7 +127,6 @@ lib/gir_ffi/flags_base.rb
 lib/gir_ffi/g_type.rb
 lib/gir_ffi/glib_error.rb
 lib/gir_ffi/in_pointer.rb
-lib/gir_ffi/info_ext
 lib/gir_ffi/info_ext.rb
 lib/gir_ffi/info_ext/full_type_name.rb
 lib/gir_ffi/info_ext/i_arg_info.rb

--- a/Rakefile
+++ b/Rakefile
@@ -35,4 +35,5 @@ load "tasks/manifest.rake"
 
 task default: "test:all"
 task default: "test:features"
+task default: "manifest:check"
 task build: "manifest:check"

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aruba", "~> 1.0.0"
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.1.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
   spec.add_development_dependency "rubocop", "~> 1.8.0"


### PR DESCRIPTION
- Update rake-manifest to version 0.2.0
- Run manifest:check as part of the default rake task
- Run manifest check as part of a linting job in CI
  - Run tests and features as separate steps
  - Make rubocop job a generic lint job
  - Add manifest check to the lint job
- Regenerate manifest so it does not list directories

ed14de1e (Matijs van Zuijlen, 8 minutes ago)