### PR TITLE
Update Dockerfile to work with current gem setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # The `-v $PWD:/gir_ffi` will make the container pick up any changes to the
 # code, so you can edit and re-run the tests.
 
-FROM ruby:2.4
+FROM ruby:2.5
 
 RUN apt-get update
 # Provides libgirepository-1.0.so.1
@@ -31,17 +31,15 @@ RUN apt-get install -y gir1.2-secret-1
 RUN apt-get install -y gir1.2-gstreamer-1.0
 RUN apt-get install -y gir1.2-gtksource-3.0
 
+# Ensure Bundler 2.x is installed
 RUN gem update bundler
 
 RUN mkdir /gir_ffi
 WORKDIR /gir_ffi
 
 # Add just the files needed for running bundle
-ADD gir_ffi.gemspec /gir_ffi/gir_ffi.gemspec
-ADD Gemfile /gir_ffi/Gemfile
+ADD Gemfile gir_ffi.gemspec Manifest.txt /gir_ffi/
 ADD lib/gir_ffi/version.rb /gir_ffi/lib/gir_ffi/version.rb
-# Yes we need to add the git repo for now
-ADD .git /gir_ffi/.git
 
 # Install dependencies
 RUN bundle


### PR DESCRIPTION
- Use Ruby 2.5 since support for 2.4 was dropped
- Make bundle installation work with the manifest file