### PR TITLE
Build on Ubuntu 18.04 to avoid JRuby build failures 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:


### PR DESCRIPTION
This is a temporary stop-gap to fix the build on CI.