### PR TITLE
Fix core dump in tests for GObject::Value garbage collection

### DIFF
--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "aruba", "~> 2.0.0"
   spec.add_development_dependency "minitest", "~> 5.12"
+  spec.add_development_dependency "minitest-focus", "~> 1.3.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"

--- a/test/base_test_helper.rb
+++ b/test/base_test_helper.rb
@@ -14,6 +14,7 @@ end
 $VERBOSE = old_verbose
 
 require "minitest/autorun"
+require "minitest/focus"
 require "rspec/mocks/minitest_integration"
 require "pry"
 


### PR DESCRIPTION
- Add minitest-focus to aid debugging test failures
- Fix core dump in tests for GObject::Value garbage collection
