### PR TITLE
Ensure Gtk 3.0 is loaded in dependency loading scenario

### DIFF
--- a/features/loading_dependencies.feature
+++ b/features/loading_dependencies.feature
@@ -7,7 +7,7 @@ Feature: Loading dependencies
       require 'gir_ffi'
 
       puts "Atk exists before: #{Object.const_defined?(:Atk)}"
-      GirFFI.setup :Gtk
+      GirFFI.setup :Gtk, "3.0"
       puts "Atk exists after: #{Object.const_defined?(:Atk)}"
       """
     When I run `ruby dependencies.rb`


### PR DESCRIPTION
Gtk 3.0 depends on Atk, but Gtk 4.0 doesn't. This meant this scenario
would fail if the introspection data for Gtk 4 was present. This change
makes sure Gtk 3.0 is loaded even in that case.
