### PR TITLE
Handle functions that have swapped closure annotation

### DIFF
--- a/lib/gir_ffi/builders/argument_builder_collection.rb
+++ b/lib/gir_ffi/builders/argument_builder_collection.rb
@@ -75,7 +75,11 @@ module GirFFI
       def set_up_user_data_relations
         @base_argument_builders.each do |bldr|
           if (idx = bldr.closure_idx) >= 0
-            @base_argument_builders[idx].mark_as_user_data bldr
+            target_bldr = @base_argument_builders[idx]
+            unless target_bldr.specialized_type_tag == :void
+              target_bldr, bldr = bldr, target_bldr
+            end
+            target_bldr.mark_as_user_data bldr
           end
         end
       end

--- a/test/gir_ffi/builders/function_builder_test.rb
+++ b/test/gir_ffi/builders/function_builder_test.rb
@@ -173,6 +173,31 @@ describe GirFFI::Builders::FunctionBuilder do
       end
     end
 
+    # NOTE: The closure annotation should normally point at the user data, but
+    # for this function, from gobject-introspection 1.67.1, the annotation points
+    # from the user data to the closure.
+    describe "for functions that have swapped closure annotation" do
+      let(:function_info) do
+        get_introspection_data "GObject", "signal_handlers_unblock_matched"
+      end
+      it "builds a correct definition" do
+        skip_below "1.67.1"
+        _(code).must_equal <<~CODE
+          def self.signal_handlers_unblock_matched(instance, mask, signal_id, detail, closure = nil, func = nil)
+            _v1 = GObject::Object.from(instance)
+            _v2 = mask
+            _v3 = signal_id
+            _v4 = detail
+            _v5 = GObject::Closure.from(closure)
+            _v6 = func
+            _v7 = GirFFI::ArgHelper.store(_v5)
+            _v8 = GObject::Lib.g_signal_handlers_unblock_matched _v1, _v2, _v3, _v4, _v5, _v6, _v7
+            return _v8
+          end
+        CODE
+      end
+    end
+
     describe "for a method with an inout array with size argument" do
       let(:function_info) do
         get_method_introspection_data "GIMarshallingTests", "Object", "method_array_inout"

--- a/test/introspection_test_helper.rb
+++ b/test/introspection_test_helper.rb
@@ -64,6 +64,8 @@ module IntrospectionTestExtensions
   end
 
   VERSION_GUARDS = {
+    "1.69.0" => %w(Regress TestObj get_string),
+    "1.67.1" => %w(GIMarshallingTests SignalsObject),
     "1.66.1" => %w(GIMarshallingTests Object vfunc_return_flags),
     "1.66.0" => %w(GIMarshallingTests Object vfunc_multiple_inout_parameters),
     "1.61.3" => %w(Regress test_array_static_in_int),
@@ -76,11 +78,11 @@ module IntrospectionTestExtensions
   LATEST_VERSION = VERSION_GUARDS.keys.first
 
   def calculate_version
-    VERSION_GUARDS.each do |version, (namespace, klass, methodname)|
-      result = if methodname
-                 get_method_introspection_data(namespace, klass, methodname)
+    VERSION_GUARDS.each do |version, (namespace, class_or_function, method_name)|
+      result = if method_name
+                 get_method_introspection_data(namespace, class_or_function, method_name)
                else
-                 get_introspection_data(namespace, klass)
+                 get_introspection_data(namespace, class_or_function)
                end
       return version if result
     end


### PR DESCRIPTION
In nearly all cases, if a function has a callable parameter and a user data parameter, the closure annotation points from the callable to the user data. However, in gobject-introspection 1.70.0, the `g_signal_handlers_unblock_matched` function is annotated the other way around.

This change checks for this and takes appropriate action.
