### PR TITLE
Improve spec descriptions for generated code

### DIFF
--- a/test/integration/generated_gio_test.rb
+++ b/test/integration/generated_gio_test.rb
@@ -5,23 +5,26 @@ require "gir_ffi_test_helper"
 GirFFI.setup :Gio
 
 # Tests generated methods and functions in the Gio namespace.
-describe "The generated Gio module" do
-  describe "File#new_for_path, a method returning an interface," do
-    it "returns an object of a more specific class" do
-      file = Gio::File.new_for_path("/")
-      _(file.class.registered_ancestors).must_equal [file.class, Gio::File, GObject::Object]
+describe Gio do
+  describe "Gio::File" do
+    describe "#new_for_path, a method returning an interface," do
+      it "returns an object of a more specific class" do
+        file = Gio::File.new_for_path("/")
+        _(file.class.registered_ancestors)
+          .must_equal [file.class, Gio::File, GObject::Object]
 
-      refute_instance_of Gio::File, file
-      assert_includes file.class.registered_ancestors, Gio::File
+        refute_instance_of Gio::File, file
+        assert_includes file.class.registered_ancestors, Gio::File
+      end
     end
   end
 
-  describe "the result of #file_new_from_path" do
+  describe "#file_new_from_path" do
     before do
       @it = Gio.file_new_for_path("/")
     end
 
-    it "is able to set up a method in a class that is not the first ancestor" do
+    it "returns an object that can set up a method in distant ancestor class" do
       refute_defines_instance_method @it.class, :get_qdata
       refute_defines_instance_method Gio::File, :get_qdata
       assert_defines_instance_method GObject::Object, :get_qdata
@@ -29,13 +32,13 @@ describe "The generated Gio module" do
       @it.setup_and_call :get_qdata, 1
     end
 
-    it "knows its GType" do
+    it "returns an object that knows its GType" do
       instance_gtype = GObject.type_from_instance @it
       _(@it.class.gtype).must_equal instance_gtype
     end
   end
 
-  describe "the FileInfo class" do
+  describe "Gio::FileInfo" do
     describe "an instance" do
       before do
         file = Gio.file_new_for_path("/")
@@ -49,12 +52,12 @@ describe "The generated Gio module" do
     end
   end
 
-  describe "the action-added signal" do
+  describe "Gio::SimpleActionGroup" do
     before do
       @grp = Gio::SimpleActionGroup.new
     end
 
-    it "correctly passes on the string parameter 'action_name'" do
+    it "handles the 'action-added' signal" do
       a = nil
       GObject.signal_connect @grp, "action-added" do |_grp, action_name, _user_data|
         a = action_name
@@ -64,12 +67,12 @@ describe "The generated Gio module" do
     end
   end
 
-  describe "the reply signal" do
+  describe "Gio::MountOperation" do
     before do
       @mo = Gio::MountOperation.new
     end
 
-    it "correctly passes on the enum parameter 'result'" do
+    it "handles the 'reply' signal" do
       a = nil
       GObject.signal_connect @mo, "reply" do |_mnt, result, _user_data|
         a = result
@@ -79,7 +82,7 @@ describe "The generated Gio module" do
     end
   end
 
-  describe "the CharsetConverter class" do
+  describe "Gio::CharsetConverter" do
     it "includes two interfaces" do
       klass = Gio::CharsetConverter
       _(klass.included_interfaces).must_equal [Gio::Initable, Gio::Converter]
@@ -92,7 +95,7 @@ describe "The generated Gio module" do
     end
   end
 
-  describe "the SocketSourceFunc callback" do
+  describe "Gio::SocketSourceFunc" do
     it "can be cast to a native function" do
       Gio::SocketSourceFunc.new { |*args| p args }.to_native
     end

--- a/test/integration/generated_glib_test.rb
+++ b/test/integration/generated_glib_test.rb
@@ -3,8 +3,8 @@
 require "gir_ffi_test_helper"
 
 # Tests generated classes, methods and functions in the GLib namespace.
-describe "The generated GLib module" do
-  it "can auto-generate the GLib::SOURCE_REMOVE constant" do
+describe GLib do
+  it "has the constant SOURCE_REMOVE" do
     _(GLib::SOURCE_REMOVE).must_equal false
   end
 end

--- a/test/integration/generated_gtk_source_test.rb
+++ b/test/integration/generated_gtk_source_test.rb
@@ -5,7 +5,7 @@ require "gir_ffi_test_helper"
 GirFFI.setup :GtkSource, "3.0"
 
 # Tests behavior of objects in the generated GtkSource namespace.
-describe "The generated GtkSource module" do
+describe GtkSource do
   describe "GtkSource::CompletionContext" do
     let(:instance) { GtkSource::CompletionContext.new }
 

--- a/test/integration/generated_gtop_test.rb
+++ b/test/integration/generated_gtop_test.rb
@@ -6,8 +6,8 @@ GirFFI.setup :GTop
 
 # Tests generated methods and functions in the GTop namespace. This namespace
 # contains types with bad names, like 'glibtop_cpu'.
-describe "The generated GTop module" do
-  describe "Glibtop" do
+describe GTop do
+  describe "GTop::Glibtop" do
     it "is a valid struct class" do
       # Superclass is either BoxedBase or StructBase, depending on library
       # versions. This means StructLikeBase is always one of the ancestors.

--- a/test/integration/generated_secret_test.rb
+++ b/test/integration/generated_secret_test.rb
@@ -4,7 +4,7 @@ require "gir_ffi_test_helper"
 
 GirFFI.setup :Secret
 
-describe "The generated Secret module" do
+describe Secret do
   describe "Secret::Schema" do
     it "has a working constructor" do
       instance = Secret::Schema.new("foo", :none, "bar" => :string)

--- a/test/integration/generated_warnlib_test.rb
+++ b/test/integration/generated_warnlib_test.rb
@@ -4,7 +4,7 @@ require "gir_ffi_test_helper"
 
 GirFFI.setup :WarnLib
 
-describe "The generated WarnLib module" do
+describe WarnLib do
   describe "WarnLib::Whatever" do
     let(:derived_klass) do
       Object.const_set("DerivedClass#{Sequence.next}", Class.new(GObject::Object))


### PR DESCRIPTION
- Always use the module name as describe argument
- Structure specs for regular modules like the ones for the
  gobject-introspection test suite models
