### PR TITLE
Unify method names to get full name for info types

### DIFF
--- a/lib/gir_ffi/builders/constructor_builder.rb
+++ b/lib/gir_ffi/builders/constructor_builder.rb
@@ -38,7 +38,7 @@ module GirFFI
           ["obj = allocate"]
         else
           [
-            "raise NoMethodError unless self == #{@info.container.full_type_name}",
+            "raise NoMethodError unless self == #{@info.container.full_name}",
             "obj = allocate"
           ]
         end

--- a/lib/gir_ffi/builders/struct_builder.rb
+++ b/lib/gir_ffi/builders/struct_builder.rb
@@ -44,7 +44,7 @@ module GirFFI
       end
 
       def gtype_struct_parent
-        full_name = info.full_type_name
+        full_name = info.full_name
         if full_name == "GObject::InitiallyUnownedClass"
           GObject::ObjectClass
         else

--- a/lib/gir_ffi/info_ext/full_type_name.rb
+++ b/lib/gir_ffi/info_ext/full_type_name.rb
@@ -5,9 +5,15 @@ module GirFFI
     # Extension module provinding a #full_type_name method suitable for
     # callbacks, constants and registered types. Signals and vfuncs need a
     # different implementation.
+    #
+    # TODO: Use only #full_name and rename this module accordingly
     module FullTypeName
       def full_type_name
         "#{safe_namespace}::#{safe_name}"
+      end
+
+      def full_name
+        full_type_name
       end
     end
   end

--- a/lib/gir_ffi/info_ext/full_type_name.rb
+++ b/lib/gir_ffi/info_ext/full_type_name.rb
@@ -2,18 +2,13 @@
 
 module GirFFI
   module InfoExt
-    # Extension module provinding a #full_type_name method suitable for
+    # Extension module provinding a #full_name method suitable for
     # callbacks, constants and registered types. Signals and vfuncs need a
     # different implementation.
     #
-    # TODO: Use only #full_name and rename this module accordingly
     module FullTypeName
-      def full_type_name
-        "#{safe_namespace}::#{safe_name}"
-      end
-
       def full_name
-        full_type_name
+        "#{safe_namespace}::#{safe_name}"
       end
     end
   end

--- a/lib/gir_ffi/info_ext/i_function_info.rb
+++ b/lib/gir_ffi/info_ext/i_function_info.rb
@@ -14,6 +14,16 @@ module GirFFI
       def return_ffi_type
         return_type.to_ffi_type
       end
+
+      def full_name
+        if method?
+          "#{container.full_name}##{safe_name}"
+        elsif container
+          "#{container.full_name}.#{safe_name}"
+        else
+          "#{safe_namespace}.#{safe_name}"
+        end
+      end
     end
   end
 end

--- a/lib/gir_ffi/info_ext/i_type_info.rb
+++ b/lib/gir_ffi/info_ext/i_type_info.rb
@@ -106,7 +106,7 @@ module GirFFI
       end
 
       def interface_class_name
-        interface.full_type_name if tag == :interface
+        interface.full_name if tag == :interface
       end
 
       def to_ffi_type

--- a/lib/gir_ffi/info_ext/i_vfunc_info.rb
+++ b/lib/gir_ffi/info_ext/i_vfunc_info.rb
@@ -22,6 +22,10 @@ module GirFFI
       def has_invoker?
         invoker
       end
+
+      def full_name
+        "#{container.full_name}::#{safe_name}"
+      end
     end
   end
 end

--- a/test/gir_ffi/info_ext/i_type_info_test.rb
+++ b/test/gir_ffi/info_ext/i_type_info_test.rb
@@ -422,7 +422,7 @@ describe GirFFI::InfoExt::ITypeInfo do
       before do
         allow(type_info).to receive(:interface).and_return iface_info
         allow(iface_info).to receive(:info_type).and_return interface_type
-        allow(iface_info).to receive(:full_type_name).and_return "Bar::Foo"
+        allow(iface_info).to receive(:full_name).and_return "Bar::Foo"
       end
 
       describe "for :struct" do


### PR DESCRIPTION
This standardises on a single `#full_name` method that can be used everywhere
an item of gobject introspection info has te be indentified uniquely.

- Add `#full_name` method to info classes
- Replace `#full_type_name` with `#full_name`
