### PR TITLE
Don't drop extra callback arguments on the floor

### DIFF
--- a/lib/gir_ffi/builders/argument_builder_collection.rb
+++ b/lib/gir_ffi/builders/argument_builder_collection.rb
@@ -139,7 +139,12 @@ module GirFFI
       def split_off_block_argument
         builders_with_name = argument_builders.select(&:method_argument_name)
         blocks, base = builders_with_name.partition(&:block_argument?)
-        return base, blocks.first
+        case blocks.count
+        when 1
+          return base, blocks.first
+        else
+          return builders_with_name, nil
+        end
       end
 
       def base_argument_names(arguments)

--- a/test/gir_ffi/builders/initializer_builder_test.rb
+++ b/test/gir_ffi/builders/initializer_builder_test.rb
@@ -37,6 +37,28 @@ describe GirFFI::Builders::InitializerBuilder do
       end
     end
 
+    describe "for constructors with multiple function arguments" do
+      let(:function_info) do
+        get_method_introspection_data "GLib", "Tree", "new_full"
+      end
+
+      it "builds a custom initializer" do
+        skip unless function_info
+
+        _(code).must_equal <<~CODE
+          def initialize_full(key_compare_func, key_destroy_func)
+            _v1 = GLib::CompareDataFunc.from(key_compare_func)
+            _v2 = GirFFI::ArgHelper.store(_v1)
+            _v3 = GLib::DestroyNotify.from(key_destroy_func)
+            _v4 = GLib::DestroyNotify.default
+            _v5 = GLib::Lib.g_tree_new_full _v1, _v2, _v3, _v4
+            store_pointer(_v5)
+            @struct.owned = true
+          end
+        CODE
+      end
+    end
+
     describe "for constructors for boxed types" do
       let(:function_info) do
         get_method_introspection_data "GIMarshallingTests", "BoxedStruct", "new"


### PR DESCRIPTION
When a function has multiple callback arguments, we can't decide easily which one should be a block argument, and we certainly shouldn't just ignore the extras. This changes the handling of callback arguments to only create a block argument if there is only one relevant callback argument.