### PR TITLE
Defining #inspect methods under ::GObjectIntrospection

### DIFF
--- a/lib/ffi-gobject_introspection/i_base_info.rb
+++ b/lib/ffi-gobject_introspection/i_base_info.rb
@@ -139,5 +139,11 @@ module GObjectIntrospection
     def ==(other)
       other.is_a?(IBaseInfo) && Lib.g_base_info_equal(self, other)
     end
+
+    def inspect
+      "#<%s 0x%x (%p %s::%s)>" % [
+        self.class, self.object_id, self.info_type, self.namespace, self.name
+      ]
+    end
   end
 end

--- a/lib/ffi-gobject_introspection/i_repository.rb
+++ b/lib/ffi-gobject_introspection/i_repository.rb
@@ -92,6 +92,14 @@ module GObjectIntrospection
       klass.wrap ptr
     end
 
+    def inspect
+      n_names = @name_cache ? @name_cache.length : 0
+      n_types = @gtype_cache ? @gtype_cache.length : 0
+      "#<%s 0x%x (cache toplevel: %d names, %d gtypes)>" % [
+        self.class, self.object_id, n_names, n_types
+      ]
+    end
+
     private
 
     def wrap_info(ptr)


### PR DESCRIPTION
**Affected Code:**

This pull would provide two #inspect methods, one onto each of the classes
- GObjectIntrospection::IRepository
- GObjectIntrospection::IBaseInfo

**Rationale:** 

The patched #inspect methods will not print the contents of instance variables.

This may serve to provide a more succinct output than the default #inspect methods, under interactive evaluation.

**Tested with:** 

Tested with Interactive evaluation (IRB) under console and in Emacs, examples provided in each changeset

**Known Limitations:**

With this patch, the updated `#inspect` method for IRepository will not present the `@names_cache` field in output. 

With the updated `#inspect` method in IBaseInfo, the result may seem far less informative - however more succinct, compared to the default `#inspect` method - as to the internal structure of an IRepository object. 

Subsequently, it may not seem as descriptive as to the internal structure of data used in e.g `GLib::GIR_FFI_BUILDER`

Perhaps this could be addressed separately, with an object inspection interface in some GTK application and for the interactive console.