### PR TITLE
Patch for GirFFI::UserDefinedObjectInfo#interfaces

### DIFF
--- a/lib/gir_ffi/user_defined_object_info.rb
+++ b/lib/gir_ffi/user_defined_object_info.rb
@@ -56,7 +56,8 @@ module GirFFI
     end
 
     def interfaces
-      (@klass.included_modules - @klass.superclass.included_modules).map(&:gir_info)
+      (@klass.included_modules - @klass.superclass.included_modules).
+        select { |m| m.respond_to?(:gir_info) }.map(&:gir_info)
     end
 
     def find_signal(_signal_name)


### PR DESCRIPTION
GirFFI::UserDefinedObjectInfo#interfaces:
- Avoiding the gir_info call on modules that do not respond to a
  gir_info method

Rationale: If a user defined widget class includes any module that does
not define a gir_info method, GirFFI::UserDefinedObjectInfo#interfaces
may err

Such an error could be raised as during a call to 'signal_connect' for a
class providing a user-defined widget type