### PR TITLE
Don't test IBaseInfo with mock pointers

### DIFF
--- a/test/ffi-gobject_introspection/i_base_info_test.rb
+++ b/test/ffi-gobject_introspection/i_base_info_test.rb
@@ -6,14 +6,7 @@ describe GObjectIntrospection::IBaseInfo do
   let(:described_class) { GObjectIntrospection::IBaseInfo }
   describe "#initialize" do
     it "raises an error if a null pointer is passed" do
-      expect(ptr = Object.new).to receive(:null?).and_return true
-      _(proc { described_class.new ptr }).must_raise ArgumentError
-    end
-
-    it "raises no error if a non-null pointer is passed" do
-      expect(ptr = Object.new).to receive(:null?).and_return false
-      described_class.new ptr
-      pass
+      _(proc { described_class.new FFI::Pointer::NULL }).must_raise ArgumentError
     end
   end
 


### PR DESCRIPTION
Using a mock pointer causes an error in IBaseInfo's finalizer. Also, the
happy path for creating IBaseInfo objects is sufficiently tested
elsewhere.
