### PR TITLE
Rename object_class to class_struct

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -117,7 +117,7 @@ module GObject
     end
 
     def property_param_spec(property_name)
-      object_class.find_property property_name or
+      class_struct.find_property property_name or
         raise GirFFI::PropertyNotFoundError.new(property_name, self.class)
     end
 

--- a/lib/ffi-gobject/object_class.rb
+++ b/lib/ffi-gobject/object_class.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-GObject::Object.object_class
+GObject::Object.class_struct
 
 module GObject
   # Overrides for GObjectClass, a struct containing GObject's class data

--- a/lib/ffi-gobject/object_class.rb
+++ b/lib/ffi-gobject/object_class.rb
@@ -3,7 +3,7 @@
 GObject::Object.class_struct
 
 module GObject
-  # Overrides for GObjectClass, a struct containing GObject's class data
+  # Overrides for GObjectClass, the class struct for GObject::Object
   class ObjectClass
     def set_property=(callback)
       struct[:set_property] = GObject::ObjectSetPropertyFunc.from callback

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -39,8 +39,8 @@ module GirFFI
         @object_class_struct ||=
           begin
             parent_struct = parent_builder.object_class_struct
-            if object_class_struct_info
-              StructBuilder.new(object_class_struct_info,
+            if class_struct_info
+              StructBuilder.new(class_struct_info,
                                 superclass: parent_struct).build_class
             else
               parent_struct
@@ -58,12 +58,6 @@ module GirFFI
         end
       end
 
-      protected
-
-      def object_class_struct_info
-        @object_class_struct_info ||= info.class_struct
-      end
-
       private
 
       def setup_class
@@ -74,6 +68,10 @@ module GirFFI
         setup_vfunc_invokers
         setup_interfaces
         setup_initializer
+      end
+
+      def class_struct_info
+        @class_struct_info ||= info.class_struct
       end
 
       # FIXME: Private method only used in subclass

--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -18,7 +18,7 @@ module GirFFI
           ObjectBase
         end
 
-        def object_class_struct
+        def class_struct_class
           GObject::TypeClass
         end
 
@@ -35,10 +35,10 @@ module GirFFI
         seek_in_ancestor_infos { |info| info.find_property property_name }
       end
 
-      def object_class_struct
-        @object_class_struct ||=
+      def class_struct_class
+        @class_struct_class ||=
           begin
-            parent_struct = parent_builder.object_class_struct
+            parent_struct = parent_builder.class_struct_class
             if class_struct_info
               StructBuilder.new(class_struct_info,
                                 superclass: parent_struct).build_class

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -133,7 +133,7 @@ module GirFFI
 
       def setup_vfuncs(object_class_ptr)
         super_class_struct =
-          superclass.gir_ffi_builder.object_class_struct::Struct.new(object_class_ptr)
+          superclass.gir_ffi_builder.class_struct_class::Struct.new(object_class_ptr)
 
         info.vfunc_implementations.each do |impl|
           setup_vfunc parent_info, super_class_struct, impl

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -109,13 +109,13 @@ module GirFFI
       end
 
       def setup_properties(object_class_ptr)
-        object_class = GObject::ObjectClass.wrap object_class_ptr
+        class_struct = GObject::ObjectClass.wrap object_class_ptr
 
-        object_class.get_property = property_getter
-        object_class.set_property = property_setter
+        class_struct.get_property = property_getter
+        class_struct.set_property = property_setter
 
         property_fields.each_with_index do |property, index|
-          object_class.install_property index + 1, property.param_spec
+          class_struct.install_property index + 1, property.param_spec
         end
       end
 

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -79,9 +79,9 @@ module GirFFI
 
       def class_init_proc
         proc do |type_class_or_ptr, _data|
-          object_class_ptr = type_class_or_ptr.to_ptr
-          setup_properties object_class_ptr
-          setup_vfuncs object_class_ptr
+          class_struct_ptr = type_class_or_ptr.to_ptr
+          setup_properties class_struct_ptr
+          setup_vfuncs class_struct_ptr
         end
       end
 
@@ -108,8 +108,8 @@ module GirFFI
         parent_gtype.class_size + interface_gtypes.sum(&:class_size)
       end
 
-      def setup_properties(object_class_ptr)
-        class_struct = GObject::ObjectClass.wrap object_class_ptr
+      def setup_properties(class_struct_ptr)
+        class_struct = GObject::ObjectClass.wrap class_struct_ptr
 
         class_struct.get_property = property_getter
         class_struct.set_property = property_setter
@@ -131,9 +131,9 @@ module GirFFI
         end
       end
 
-      def setup_vfuncs(object_class_ptr)
+      def setup_vfuncs(class_struct_ptr)
         super_class_struct =
-          superclass.gir_ffi_builder.class_struct_class::Struct.new(object_class_ptr)
+          superclass.gir_ffi_builder.class_struct_class::Struct.new(class_struct_ptr)
 
         info.vfunc_implementations.each do |impl|
           setup_vfunc parent_info, super_class_struct, impl

--- a/lib/gir_ffi/object_base.rb
+++ b/lib/gir_ffi/object_base.rb
@@ -7,7 +7,7 @@ module GirFFI
   class ObjectBase < ClassBase
     extend FFI::DataConverter
 
-    def object_class
+    def class_struct
       self.class.class_struct
     end
 

--- a/lib/gir_ffi/object_base.rb
+++ b/lib/gir_ffi/object_base.rb
@@ -8,7 +8,7 @@ module GirFFI
     extend FFI::DataConverter
 
     def object_class
-      self.class.object_class
+      self.class.class_struct
     end
 
     def self.native_type
@@ -64,8 +64,8 @@ module GirFFI
         raise GirFFI::SignalNotFoundError.new(name, self)
     end
 
-    def self.object_class
-      @object_class ||=
+    def self.class_struct
+      @class_struct ||=
         begin
           ptr = GObject::Lib.g_type_class_ref(gtype)
           gir_ffi_builder.object_class_struct.wrap ptr

--- a/lib/gir_ffi/object_base.rb
+++ b/lib/gir_ffi/object_base.rb
@@ -68,7 +68,7 @@ module GirFFI
       @class_struct ||=
         begin
           ptr = GObject::Lib.g_type_class_ref(gtype)
-          gir_ffi_builder.object_class_struct.wrap ptr
+          gir_ffi_builder.class_struct_class.wrap ptr
         end
     end
 

--- a/test/ffi-gobject/gobject_test.rb
+++ b/test/ffi-gobject/gobject_test.rb
@@ -51,10 +51,10 @@ describe GObject do
   describe "::object_class_from_instance" do
     it "returns a GObject::ObjectClass with the correct GType" do
       obj = GIMarshallingTests::OverridesObject.new
-      object_class = GObject.object_class_from_instance obj
-      gtype = object_class.g_type_class.g_type
+      class_struct = GObject.object_class_from_instance obj
+      gtype = class_struct.g_type_class.g_type
 
-      _(object_class).must_be_instance_of GObject::ObjectClass
+      _(class_struct).must_be_instance_of GObject::ObjectClass
       _(gtype).must_equal GIMarshallingTests::OverridesObject.gtype
     end
   end

--- a/test/ffi-gobject/object_class_test.rb
+++ b/test/ffi-gobject/object_class_test.rb
@@ -8,13 +8,13 @@ describe GObject::ObjectClass do
   describe "#list_properties" do
     it "returns GIMarshallingTests::OverridesObject's properties" do
       obj = GIMarshallingTests::OverridesObject.new
-      object_class = GObject.object_class_from_instance obj
+      class_struct = GObject.object_class_from_instance obj
 
       info = get_introspection_data "GIMarshallingTests", "OverridesObject"
       expected_props = info.properties.map(&:name)
       expected_props += info.parent.properties.map(&:name)
 
-      props = object_class.list_properties
+      props = class_struct.list_properties
       prop_names = props.map(&:get_name)
 
       _(prop_names.sort).must_equal expected_props.sort
@@ -24,8 +24,8 @@ describe GObject::ObjectClass do
   describe "#gtype" do
     it "returns the correct GType" do
       obj = GIMarshallingTests::OverridesObject.new
-      object_class = GObject.object_class_from_instance obj
-      _(object_class.gtype).must_equal GIMarshallingTests::OverridesObject.gtype
+      class_struct = GObject.object_class_from_instance obj
+      _(class_struct.gtype).must_equal GIMarshallingTests::OverridesObject.gtype
     end
   end
 end

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -80,8 +80,8 @@ describe GirFFI::Builder do
     end
 
     it "returns a valid class for boxed classes unknown to GIR" do
-      object_class = GIMarshallingTests::PropertiesObject.object_class
-      property = object_class.find_property "some-boxed-glist"
+      class_struct = GIMarshallingTests::PropertiesObject.class_struct
+      property = class_struct.find_property "some-boxed-glist"
       gtype = property.value_type
 
       _(gtype).wont_equal GObject::TYPE_NONE

--- a/test/gir_ffi/builders/object_builder_test.rb
+++ b/test/gir_ffi/builders/object_builder_test.rb
@@ -54,22 +54,22 @@ describe GirFFI::Builders::ObjectBuilder do
     end
   end
 
-  describe "#object_class_struct" do
+  describe "#class_struct_class" do
     it "returns the class struct type" do
-      _(obj_builder.object_class_struct).must_equal Regress::TestObjClass
+      _(obj_builder.class_struct_class).must_equal Regress::TestObjClass
     end
 
     it "returns the parent struct type for classes without their own struct" do
       binding_info = get_introspection_data "GObject", "Binding"
       builder = GirFFI::Builders::ObjectBuilder.new binding_info
-      _(builder.object_class_struct).must_equal GObject::ObjectClass
+      _(builder.class_struct_class).must_equal GObject::ObjectClass
     end
 
     it "returns a valid class for disguised type classes" do
       binding_info = get_introspection_data "Regress", "FooBuffer"
       builder = GirFFI::Builders::ObjectBuilder.new binding_info
 
-      _(builder.object_class_struct.name).must_equal "Regress::FooBufferClass"
+      _(builder.class_struct_class.name).must_equal "Regress::FooBufferClass"
     end
   end
 

--- a/test/gir_ffi/builders/unintrospectable_boxed_builder_test.rb
+++ b/test/gir_ffi/builders/unintrospectable_boxed_builder_test.rb
@@ -6,7 +6,7 @@ GirFFI.setup :GIMarshallingTests
 
 describe GirFFI::Builders::UnintrospectableBoxedBuilder do
   let(:instance) { GIMarshallingTests::PropertiesObject.new }
-  let(:property) { instance.object_class.find_property "some-boxed-glist" }
+  let(:property) { instance.class_struct.find_property "some-boxed-glist" }
   let(:gtype) { property.value_type }
   let(:info) { GirFFI::UnintrospectableBoxedInfo.new(gtype) }
   let(:bldr) { GirFFI::Builders::UnintrospectableBoxedBuilder.new(info) }

--- a/test/gir_ffi/builders/unintrospectable_builder_test.rb
+++ b/test/gir_ffi/builders/unintrospectable_builder_test.rb
@@ -46,9 +46,9 @@ describe GirFFI::Builders::UnintrospectableBuilder do
       end
     end
 
-    describe "#object_class_struct" do
-      it "returns the parent class struct" do
-        _(@bldr.object_class_struct).must_equal GObject::ObjectClass
+    describe "#class_struct_class" do
+      it "returns the parent class' class struct class" do
+        _(@bldr.class_struct_class).must_equal GObject::ObjectClass
       end
     end
   end

--- a/test/gir_ffi/builders/user_defined_builder_test.rb
+++ b/test/gir_ffi/builders/user_defined_builder_test.rb
@@ -520,9 +520,9 @@ describe GirFFI::Builders::UserDefinedBuilder do
     end
   end
 
-  describe "#object_class_struct" do
-    it "returns the parent class struct" do
-      _(builder.object_class_struct).must_equal GIMarshallingTests::ObjectClass
+  describe "#class_struct_class" do
+    it "returns the parent class' class struct class" do
+      _(builder.class_struct_class).must_equal GIMarshallingTests::ObjectClass
     end
   end
 end

--- a/test/gir_ffi/class_base_test.rb
+++ b/test/gir_ffi/class_base_test.rb
@@ -4,23 +4,23 @@ require "gir_ffi_test_helper"
 
 describe GirFFI::ClassBase do
   describe "a simple descendant" do
-    let(:object_class) do
+    let(:class_struct) do
       Class.new(GirFFI::ClassBase) do
         self::Struct = Class.new(GirFFI::Struct) do
           layout :foo, :int32
         end
       end
     end
-    let(:object) { object_class.wrap FFI::MemoryPointer.new(:int32) }
+    let(:object) { class_struct.wrap FFI::MemoryPointer.new(:int32) }
 
     it "has #from as a pass-through method" do
-      result = object_class.from :foo
+      result = class_struct.from :foo
       _(result).must_equal :foo
     end
 
     describe "#==" do
       it "returns true for an object of the same class and pointer" do
-        other = object_class.wrap object.to_ptr
+        other = class_struct.wrap object.to_ptr
 
         _(object).must_be :==, other
         _(other).must_be :==, object
@@ -28,14 +28,14 @@ describe GirFFI::ClassBase do
 
       it "returns true for an object of the same class and pointer with the same address" do
         ptr = FFI::Pointer.new object.to_ptr
-        other = object_class.wrap ptr
+        other = class_struct.wrap ptr
 
         _(object).must_be :==, other
         _(other).must_be :==, object
       end
 
       it "returns false for an object of a sub/superclass and the same pointer" do
-        subclass = Class.new(object_class)
+        subclass = Class.new(class_struct)
         other = subclass.wrap object.to_ptr
 
         _(object).wont_be :==, other
@@ -43,7 +43,7 @@ describe GirFFI::ClassBase do
       end
 
       it "returns false for an object of the same class and different pointer" do
-        other = object_class.wrap FFI::MemoryPointer.new(:int32)
+        other = class_struct.wrap FFI::MemoryPointer.new(:int32)
 
         _(object).wont_be :==, other
         _(other).wont_be :==, object

--- a/test/gir_ffi/ffi_ext/pointer_test.rb
+++ b/test/gir_ffi/ffi_ext/pointer_test.rb
@@ -8,13 +8,13 @@ describe GirFFI::FFIExt::Pointer do
     it "finds the wrapping class by gtype and wraps the pointer in it" do
       ptr = pointer_class.new
       expect(ptr).to receive(:null?).and_return false
-      object_class = Class.new
+      klass = Class.new
 
       expect(GObject)
         .to receive(:type_from_instance_pointer).with(ptr).and_return 0xdeadbeef
       expect(GirFFI::Builder)
-        .to receive(:build_by_gtype).with(0xdeadbeef).and_return object_class
-      expect(object_class).to receive(:direct_wrap).with(ptr).and_return "good-result"
+        .to receive(:build_by_gtype).with(0xdeadbeef).and_return klass
+      expect(klass).to receive(:direct_wrap).with(ptr).and_return "good-result"
 
       _(ptr.to_object).must_equal "good-result"
     end

--- a/test/gir_ffi/object_base_test.rb
+++ b/test/gir_ffi/object_base_test.rb
@@ -21,14 +21,14 @@ describe GirFFI::ObjectBase do
     end
   end
 
-  describe ".object_class" do
+  describe ".class_struct" do
     it "returns an object of the class struct type" do
-      _(Regress::TestObj.object_class).must_be_instance_of Regress::TestObjClass
+      _(Regress::TestObj.class_struct).must_be_instance_of Regress::TestObjClass
     end
 
     it "caches its result" do
-      first = Regress::TestObj.object_class
-      second = Regress::TestObj.object_class
+      first = Regress::TestObj.class_struct
+      second = Regress::TestObj.class_struct
       _(second).must_be :eql?, first
     end
   end

--- a/test/integration/generated_gobject_test.rb
+++ b/test/integration/generated_gobject_test.rb
@@ -23,14 +23,14 @@ describe GObject do
   describe GObject::TypeInfo do
     let(:instance) { GObject::TypeInfo.new }
     it "has a working field setter for class_init" do
-      instance.class_init = proc do |_object_class, _data|
+      instance.class_init = proc do |_class_struct, _data|
         # nothing
       end
     end
 
     it "has a working field getter for class_init" do
       _(instance.class_init).must_be_nil
-      instance.class_init = proc do |_object_class, _data|
+      instance.class_init = proc do |_class_struct, _data|
         # nothing
       end
       result = instance.class_init

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -3528,7 +3528,7 @@ describe Regress do
     skip_below "1.51.2"
     instance = Regress.test_create_fundamental_hidden_class_instance
     _(instance).must_be_kind_of Regress::TestFundamentalObject
-    g_type = instance.object_class.g_type
+    g_type = instance.class_struct.g_type
     _(GObject.type_name(g_type)).must_equal "RegressTestFundamentalHiddenSubObject"
   end
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1640,7 +1640,7 @@ describe Regress do
       # Make sure Regress::TestObjClass exists
       # NOTE: Perhaps gtype struct classes should be stored out of the way in
       # some other namespace.
-      Regress::TestObj.object_class
+      Regress::TestObj.class_struct
 
       _(Regress::TestObjClass.const_defined?(:Matrix)).must_equal true
       _(Regress.const_defined?(:Matrix)).must_equal false


### PR DESCRIPTION
- Rename `ObjectBase.object_class` to `class_struct`
- Improve description of `GObject::ObjectClass`
- Rename `ObjectBase#object_class` to `class_struct`
- Rename `ObjectBuilder#object_class_struct_info` and make it private
- Rename `ObjectBuilder#object_class_struct` to `class_struct_class`
- Rename variables named `object_class`
- Rename parameters and variables with names related to `object_class`
