### PR TITLE
Remove GObject.object_class_from_instance

### DIFF
--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -31,17 +31,6 @@ module GObject
     type_name type_from_instance instance
   end
 
-  def self.object_class_from_instance(instance)
-    object_class_from_instance_pointer instance.to_ptr
-  end
-
-  def self.object_class_from_instance_pointer(inst_ptr)
-    return nil if inst_ptr.null?
-
-    klsptr = inst_ptr.get_pointer 0
-    ObjectClass.wrap klsptr
-  end
-
   def self.signal_lookup_from_instance(signal, object)
     signal_lookup signal, type_from_instance(object)
   end

--- a/test/ffi-gobject/gobject_test.rb
+++ b/test/ffi-gobject/gobject_test.rb
@@ -48,17 +48,6 @@ describe GObject do
     _(GObject.type_name(GObject::TYPE_STRV)).must_equal       "GStrv"
   end
 
-  describe "::object_class_from_instance" do
-    it "returns a GObject::ObjectClass with the correct GType" do
-      obj = GIMarshallingTests::OverridesObject.new
-      class_struct = GObject.object_class_from_instance obj
-      gtype = class_struct.g_type_class.g_type
-
-      _(class_struct).must_be_instance_of GObject::ObjectClass
-      _(gtype).must_equal GIMarshallingTests::OverridesObject.gtype
-    end
-  end
-
   describe "creating ParamSpecs" do
     describe "#param_spec_int" do
       it "creates a GObject::ParamSpecInt" do

--- a/test/ffi-gobject/object_class_test.rb
+++ b/test/ffi-gobject/object_class_test.rb
@@ -8,7 +8,7 @@ describe GObject::ObjectClass do
   describe "#list_properties" do
     it "returns GIMarshallingTests::OverridesObject's properties" do
       obj = GIMarshallingTests::OverridesObject.new
-      class_struct = GObject.object_class_from_instance obj
+      class_struct = obj.class_struct
 
       info = get_introspection_data "GIMarshallingTests", "OverridesObject"
       expected_props = info.properties.map(&:name)
@@ -24,7 +24,7 @@ describe GObject::ObjectClass do
   describe "#gtype" do
     it "returns the correct GType" do
       obj = GIMarshallingTests::OverridesObject.new
-      class_struct = GObject.object_class_from_instance obj
+      class_struct = obj.class_struct
       _(class_struct.gtype).must_equal GIMarshallingTests::OverridesObject.gtype
     end
   end


### PR DESCRIPTION
Finding the `class_struct` is best done by calling the `#class_struct` method on the instance intead.
