### PR TITLE
Remove deprecated methods from GObject::Object

### DIFF
--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -123,11 +123,6 @@ module GObject
 
     # Overrides for GObject, GObject's generic base class.
     module Overrides
-      # @deprecated
-      def get_property_extended(property_name)
-        get_property(property_name)
-      end
-
       def get_property(property_name)
         gvalue = gvalue_for_property property_name
         super property_name, gvalue
@@ -137,11 +132,6 @@ module GObject
         value = property_value_post_conversion(value, type_info) if type_info
 
         value
-      end
-
-      # @deprecated
-      def set_property_extended(property_name, value)
-        set_property property_name, value
       end
 
       def set_property(property_name, value)

--- a/test/ffi-gobject/object_test.rb
+++ b/test/ffi-gobject/object_test.rb
@@ -42,26 +42,10 @@ describe GObject::Object do
     end
   end
 
-  describe "#get_property_extended" do
-    it "raises an error for a property that does not exist" do
-      instance = GObject::Object.new
-      _(proc { instance.get_property_extended "foo-bar" })
-        .must_raise GirFFI::PropertyNotFoundError
-    end
-  end
-
   describe "#set_property" do
     it "raises an error for a property that does not exist" do
       instance = GObject::Object.new
       _(proc { instance.set_property "foo-bar", 123 })
-        .must_raise GirFFI::PropertyNotFoundError
-    end
-  end
-
-  describe "#set_property_extended" do
-    it "raises an error for a property that does not exist" do
-      instance = GObject::Object.new
-      _(proc { instance.set_property_extended "foo-bar", 123 })
         .must_raise GirFFI::PropertyNotFoundError
     end
   end


### PR DESCRIPTION
This removes the deprecated methods `#get_property_extended` and `#set_property_extended`. The regular `#get_property` and `#set_property` methods have indentical functionality and should be used instead.
