### PR TITLE
Refactor integration test generator

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Lint/MissingSuper:
 
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 26
+  Max: 21
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
@@ -42,10 +42,6 @@ Metrics/MethodLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
   Max: 216
-
-# Configuration parameters: IgnoredMethods.
-Metrics/PerceivedComplexity:
-  Max: 9
 
 # Configuration parameters: EnforcedStyleForLeadingUnderscores.
 # SupportedStylesForLeadingUnderscores: disallowed, required, optional

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,10 +18,6 @@ Lint/MissingSuper:
     - 'lib/gir_ffi/struct_like_base.rb'
     - 'test/minitest/stats_plugin.rb'
 
-# Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 21
-
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
 Metrics/BlockLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Lint/MissingSuper:
 
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 60
+  Max: 26
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 # IgnoredMethods: refine
@@ -33,11 +33,11 @@ Metrics/ClassLength:
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 19
+  Max: 13
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
-  Max: 57
+  Max: 36
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
@@ -45,7 +45,7 @@ Metrics/ModuleLength:
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
-  Max: 14
+  Max: 9
 
 # Configuration parameters: EnforcedStyleForLeadingUnderscores.
 # SupportedStylesForLeadingUnderscores: disallowed, required, optional

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,11 +33,11 @@ Metrics/ClassLength:
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 12
+  Max: 8
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
-  Max: 31
+  Max: 15
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,10 +27,6 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 181
 
-# Configuration parameters: IgnoredMethods.
-Metrics/CyclomaticComplexity:
-  Max: 8
-
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
   Max: 15

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,11 +33,11 @@ Metrics/ClassLength:
 
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 13
+  Max: 12
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
-  Max: 36
+  Max: 31
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -53,16 +53,10 @@ class Listener
     return if skipping
 
     case tag
-    when "constant"
-      end_constant
-    when "record", "class", "enumeration", "bitfield", "interface", "union"
-      end_object
-    when "function", "method", "constructor", "member", "property", "glib:signal"
-      end_functionish
-    when "field"
-      end_field
-    when "namespace"
-      end_namespace
+    when *HANDLED_TAGS
+      send "end_#{tag}"
+    when "glib:signal"
+      end_signal
     end
   end
 
@@ -170,13 +164,26 @@ class Listener
     emit_indented 2, "end" unless @class_stack.any?
   end
 
-  def end_functionish
+  alias end_record end_object
+  alias end_class end_object
+  alias end_enumeration end_object
+  alias end_bitfield end_object
+  alias end_interface end_object
+  alias end_union end_object
+
+  def end_function
     if @class_stack.any?
       emit_indented 4, "end"
     else
       emit_indented 2, "end"
     end
   end
+
+  alias end_constructor end_function
+  alias end_method end_function
+  alias end_member end_function
+  alias end_property end_function
+  alias end_signal end_function
 
   def end_field
     emit_indented 4, "end" if current_object_type != "class"

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -67,23 +67,15 @@ class Listener
 
     case tag
     when "constant"
-      result.puts "  end"
-    when "record", "class", "enumeration", "bitfield",
-      "interface", "union"
-      @class_stack.pop
-      result.puts "  end" unless @class_stack.any?
-    when "function", "method"
-      if @class_stack.any?
-        result.puts "    end"
-      else
-        result.puts "  end"
-      end
-    when "constructor", "member", "property", "glib:signal"
-      result.puts "    end"
+      end_constant
+    when "record", "class", "enumeration", "bitfield", "interface", "union"
+      end_object
+    when "function", "method", "constructor", "member", "property", "glib:signal"
+      end_functionish
     when "field"
-      result.puts "    end" if current_object_type != "class"
+      end_field
     when "namespace"
-      result.puts "end"
+      end_namespace
     end
   end
 
@@ -146,6 +138,31 @@ class Listener
 
   def start_signal(obj_name)
     result.puts "    it \"handles the '#{obj_name}' signal\" do"
+  end
+
+  def end_constant
+    result.puts "  end"
+  end
+
+  def end_object
+    @class_stack.pop
+    result.puts "  end" unless @class_stack.any?
+  end
+
+  def end_functionish
+    if @class_stack.any?
+      result.puts "    end"
+    else
+      result.puts "  end"
+    end
+  end
+
+  def end_field
+    result.puts "    end" if current_object_type != "class"
+  end
+
+  def end_namespace
+    result.puts "end"
   end
 
   def skippable?(attrs)


### PR DESCRIPTION
- Break up large method Listener#tag_start
- Break up large method Listener#tag_end
- Extract Listener methods #push_state and #pop_state
- Unify start tag handling in Listener#tag_start
- Simplify Listener#start_property using a custom indenting method
- Unify end tag handling in Listener#tag_end
