### PR TITLE
Process some NOTE comments

### DIFF
--- a/lib/ffi-glib/bytes.rb
+++ b/lib/ffi-glib/bytes.rb
@@ -7,18 +7,6 @@ module GLib
   class Bytes
     include Enumerable
 
-    remove_method :get_data if method_defined? :get_data
-
-    # @override
-    # NOTE: Needed due to mis-identification of the element-type of the
-    # resulting sized array for the default binding.
-    def get_data
-      length_ptr = FFI::MemoryPointer.new :size_t
-      data_ptr = Lib.g_bytes_get_data self, length_ptr
-      length = length_ptr.get_size_t(0)
-      GirFFI::SizedArray.wrap(:guint8, length, data_ptr)
-    end
-
     def each(&block)
       data.each(&block)
     end

--- a/lib/ffi-glib/variant.rb
+++ b/lib/ffi-glib/variant.rb
@@ -14,13 +14,11 @@ module GLib
     alias get_string_without_override get_string
     alias get_string get_string_with_override
 
-    # Initializing method used in constructors. For Variant, this needs to sink
-    # the variant's floating reference.
+    # Initializing method used in constructors. For Variant the constructing
+    # functions all return floating references, so this is need to take full
+    # ownership.
     #
-    # NOTE: This is very hard to test since it is not possible to get the
-    # variant's ref count directely. However, there is an error when running
-    # the tests on 32-bit systems.
-    #
+    # Also see the documentation for g_variant_ref_sink.
     def store_pointer(ptr)
       Lib.g_variant_ref_sink ptr
       super

--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -70,7 +70,8 @@ module GObject
   load_class :ClosureMarshal
   load_class :ParamFlags
 
-  # NOTE: This Lib module is set up in `gir_ffi-base/gobject/lib.rb`.
+  # Attach some needed functions to the GObject Lib, which was set up in
+  # `gir_ffi-base/gobject/lib.rb`.
   Lib.class_eval do
     attach_function :g_object_ref_sink, [:pointer], :pointer
     attach_function :g_object_ref, [:pointer], :pointer

--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -44,11 +44,7 @@ module GObject
     argument_gvalues = sig_info.arguments_to_gvalues object, args
     return_gvalue = sig_info.gvalue_for_return_value
 
-    result = signal_emitv argument_gvalues, signal_id, detail_quark, return_gvalue
-    # NOTE: Depending on the version of GObjectIntrospection, the result will
-    # be stored in result or return_gvalue. This was changed between versions
-    # 1.44 and 1.46.
-    result || return_gvalue.get_value
+    signal_emitv argument_gvalues, signal_id, detail_quark, return_gvalue
   end
 
   def self.signal_connect(object, detailed_signal, data = nil, after = false, &block)

--- a/test/ffi-glib/variant_test.rb
+++ b/test/ffi-glib/variant_test.rb
@@ -3,6 +3,13 @@
 require "gir_ffi_test_helper"
 
 describe GLib::Variant do
+  describe "#new_string" do
+    it "sinks the reference for resulting variant" do
+      var = GLib::Variant.new_string("Foo")
+      _(var.is_floating).must_equal false
+    end
+  end
+
   describe "#get_string" do
     it "returns just the contained string" do
       var = GLib::Variant.new_string("Foo")


### PR DESCRIPTION
- Clean up old code only relevant for old GObjectIntrospection versions
- Test that GLib::Variant constructors sink references
- Improve comment
- Remove obsolete override
