### PR TITLE
Refactor UserDefinedBuilder

### DIFF
--- a/lib/ffi-gobject/object_class.rb
+++ b/lib/ffi-gobject/object_class.rb
@@ -5,14 +5,6 @@ GObject::Object.class_struct
 module GObject
   # Overrides for GObjectClass, the class struct for GObject::Object
   class ObjectClass
-    def set_property=(callback)
-      struct[:set_property] = GObject::ObjectSetPropertyFunc.from callback
-    end
-
-    def get_property=(callback)
-      struct[:get_property] = GObject::ObjectGetPropertyFunc.from callback
-    end
-
     def gtype
       to_ptr.get_gtype 0
     end

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -78,17 +78,17 @@ module GirFFI
       end
 
       def class_init_proc
-        proc do |type_class_or_ptr, _data|
-          class_struct_ptr = type_class_or_ptr.to_ptr
+        proc do |type_class, _data|
+          class_struct_ptr = type_class.to_ptr
           setup_properties class_struct_ptr
           setup_vfuncs class_struct_ptr
         end
       end
 
       def interface_init_proc(interface)
-        proc do |interface_or_ptr, _data|
-          interface_ptr = interface_or_ptr.to_ptr
-          setup_interface_vfuncs interface, interface_ptr
+        proc do |type_interface, _data|
+          interface_struct_ptr = type_interface.to_ptr
+          setup_interface_vfuncs interface, interface_struct_ptr
         end
       end
 
@@ -140,10 +140,10 @@ module GirFFI
         end
       end
 
-      def setup_interface_vfuncs(interface, interface_ptr)
+      def setup_interface_vfuncs(interface, interface_struct_ptr)
         interface_builder = interface.gir_ffi_builder
 
-        interface_struct = interface_builder.interface_struct.wrap(interface_ptr)
+        interface_struct = interface_builder.interface_struct.wrap(interface_struct_ptr)
         interface_info = interface_builder.info
 
         info.vfunc_implementations.each do |impl|

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -156,12 +156,8 @@ module GirFFI
         vfunc_info = ancestor_info.find_vfunc vfunc_name.to_s
         return unless vfunc_info
 
-        install_vfunc ancestor_struct, vfunc_name, vfunc_info, impl.implementation
-      end
-
-      def install_vfunc(container_struct, vfunc_name, vfunc_info, implementation)
         vfunc_class = VFuncBuilder.new(vfunc_info).build_class
-        container_struct.struct[vfunc_name] = vfunc_class.from(implementation)
+        ancestor_struct.struct[vfunc_name] = vfunc_class.from(impl.implementation)
       end
 
       def properties

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -133,7 +133,7 @@ module GirFFI
 
       def setup_vfuncs(class_struct_ptr)
         super_class_struct =
-          superclass.gir_ffi_builder.class_struct_class::Struct.new(class_struct_ptr)
+          superclass.gir_ffi_builder.class_struct_class.wrap(class_struct_ptr)
 
         info.vfunc_implementations.each do |impl|
           setup_vfunc parent_info, super_class_struct, impl
@@ -143,7 +143,7 @@ module GirFFI
       def setup_interface_vfuncs(interface, interface_ptr)
         interface_builder = interface.gir_ffi_builder
 
-        interface_struct = interface_builder.interface_struct::Struct.new(interface_ptr)
+        interface_struct = interface_builder.interface_struct.wrap(interface_ptr)
         interface_info = interface_builder.info
 
         info.vfunc_implementations.each do |impl|
@@ -160,8 +160,8 @@ module GirFFI
       end
 
       def install_vfunc(container_struct, vfunc_name, vfunc_info, implementation)
-        vfunc = VFuncBuilder.new(vfunc_info).build_class
-        container_struct[vfunc_name] = vfunc.from implementation
+        vfunc_class = VFuncBuilder.new(vfunc_info).build_class
+        container_struct.struct[vfunc_name] = vfunc_class.from(implementation)
       end
 
       def properties


### PR DESCRIPTION
- Use ClassBase.wrap to wrap type class pointers
- Inline #install_vfunc method
- Rename variables and parameters to match their use
- Inline slightly broken #set_property= and #get_property= methods
