### PR TITLE
Check parameter direction in signal argument conversion

### DIFF
--- a/lib/gir_ffi/info_ext/i_signal_info.rb
+++ b/lib/gir_ffi/info_ext/i_signal_info.rb
@@ -17,8 +17,14 @@ module GirFFI
       end
 
       def arguments_to_gvalues(instance, arguments)
-        arg_g_values = argument_types.zip(arguments).map do |type, arg|
-          type.make_g_value.tap { |it| it.set_value arg }
+        arg_g_values = args.zip(arguments).map do |arg_info, arg|
+          case arg_info.direction
+          when :in
+            type = arg_info.argument_type
+            type.make_g_value.tap { |it| it.set_value arg }
+          else
+            raise NotImplementedError
+          end
         end
 
         arg_g_values.unshift GObject::Value.wrap_instance(instance)
@@ -26,10 +32,6 @@ module GirFFI
 
       def gvalue_for_return_value
         return_type.make_g_value
-      end
-
-      def argument_types
-        @argument_types ||= args.map(&:argument_type)
       end
     end
   end

--- a/test/ffi-gobject_test.rb
+++ b/test/ffi-gobject_test.rb
@@ -59,6 +59,16 @@ describe GObject do
 
       _(a).must_equal 2
     end
+
+    it "raises an error for signals with inout arguments" do
+      skip_below "1.57.2"
+      obj = Regress::TestObj.constructor
+      obj.signal_connect "sig-with-inout-int" do |_obj, i, _ud|
+        i + 1
+      end
+      _(proc { GObject.signal_emit obj, "sig-with-inout-int", 0 })
+        .must_raise NotImplementedError
+    end
   end
 
   describe "::signal_connect" do


### PR DESCRIPTION
When the argument direction is not :in, the existing conversion method does not work, so check that.
