### PR TITLE
Drop support for JRuby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,11 +19,11 @@ env:
 jobs:
   test:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1", jruby-9.3]
+        ruby: [2.6, 2.7, "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ examples can be found in `gir_ffi-gtk` and `gir_ffi-gst`.
 
 ## Requirements
 
-GirFFI is supported on CRuby 2.6, 2.7 and 3.0, and JRuby 9.3.
+GirFFI is supported on CRuby 2.6, 2.7, 3.0 and 3.1.
 
 You will also need gobject-introspection installed with some
 introspection data.

--- a/features/step_definitions/waiting.rb
+++ b/features/step_definitions/waiting.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
 When(/^I wait some time for a command to start up$/) do
-  time = case RUBY_ENGINE
-         when "jruby"
-           10
-         when "rbx"
-           4
-         else
-           1
-         end
-  step "I wait #{time} seconds for a command to start up"
+  step "I wait 1 second for a command to start up"
 end

--- a/lib/ffi-glib/main_loop.rb
+++ b/lib/ffi-glib/main_loop.rb
@@ -40,7 +40,7 @@ module GLib
     setup_instance_method! :run
 
     def run_with_thread_enabler
-      ThreadEnabler.instance.setup_idle_handler if RUBY_ENGINE == "ruby"
+      ThreadEnabler.instance.setup_idle_handler
       RUNNING_LOOPS << self
       result = run_without_thread_enabler
       exception = EXCEPTIONS.shift

--- a/lib/gir_ffi/class_base.rb
+++ b/lib/gir_ffi/class_base.rb
@@ -29,10 +29,8 @@ module GirFFI
       send method_name, *arguments, &block
     end
 
-    # NOTE: JRuby should fix FFI::MemoryPointer#== to return true for
-    # equivalent FFI::Pointer. For now, user to_ptr.address
     def ==(other)
-      other.class == self.class && to_ptr.address == other.to_ptr.address
+      other.class == self.class && to_ptr == other.to_ptr
     end
 
     def self.setup_and_call(method, arguments, &block)

--- a/lib/gir_ffi/info_ext/i_type_info.rb
+++ b/lib/gir_ffi/info_ext/i_type_info.rb
@@ -214,13 +214,7 @@ module GirFFI
       end
 
       def subtype_ffi_type(index)
-        subtype = param_type(index).to_ffi_type
-        if subtype == :pointer
-          # NOTE: Don't use pointer directly to appease JRuby.
-          :"uint#{FFI.type_size(:pointer) * 8}"
-        else
-          subtype
-        end
+        param_type(index).to_ffi_type
       end
 
       def flattened_array_type

--- a/lib/gir_ffi/struct_like_base.rb
+++ b/lib/gir_ffi/struct_like_base.rb
@@ -22,7 +22,6 @@ module GirFFI
         self
       end
 
-      # NOTE: Needed for JRuby's FFI
       def to_native(value, _context)
         value.struct
       end


### PR DESCRIPTION
On latest Ubuntu and on Debian sid, JRuby has (different) problems with GirFFI that I don't know how to debug and fix. Because of this, and in preparation of dropping support for Ruby 2.6, drop support for JRuby.

- Drop official support for JRuby
- Remove workarounds for JRuby support
- Remove incorrect comment
- Remove ruby-engine specific code from step definition
- Remove ruby-engine specific code from GLib::MainLoop
