### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
   Exclude:
     - 'examples/*'
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "http://www.github.com/mvz/ruby-gir-ffi"
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi"

--- a/lib/gir_ffi/builders/argument_builder_collection.rb
+++ b/lib/gir_ffi/builders/argument_builder_collection.rb
@@ -28,11 +28,11 @@ module GirFFI
 
       def capture_variable_names
         @capture_variable_names ||=
-          all_builders.map(&:capture_variable_name).compact
+          all_builders.filter_map(&:capture_variable_name)
       end
 
       def call_argument_names
-        @call_argument_names ||= argument_builders.map(&:call_argument_name).compact
+        @call_argument_names ||= argument_builders.filter_map(&:call_argument_name)
       end
 
       def method_argument_names
@@ -50,7 +50,7 @@ module GirFFI
       end
 
       def return_value_names
-        @return_value_names ||= all_builders.map(&:return_value_name).compact
+        @return_value_names ||= all_builders.filter_map(&:return_value_name)
       end
 
       def has_return_values?
@@ -149,7 +149,7 @@ module GirFFI
 
       def base_argument_names(arguments)
         required_found = false
-        arguments.reverse.map do |it|
+        arguments.reverse.filter_map do |it|
           name = it.method_argument_name
           if it.allow_none? && !required_found
             "#{name} = nil"
@@ -157,7 +157,7 @@ module GirFFI
             required_found = true
             name
           end
-        end.compact.reverse
+        end.reverse
       end
     end
   end

--- a/lib/gir_ffi/unintrospectable_type_info.rb
+++ b/lib/gir_ffi/unintrospectable_type_info.rb
@@ -37,9 +37,9 @@ module GirFFI
     end
 
     def interfaces
-      @gobject.type_interfaces(@g_type).map do |gtype|
+      @gobject.type_interfaces(@g_type).filter_map do |gtype|
         @gir.find_by_gtype gtype
-      end.compact
+      end
     end
 
     def fields


### PR DESCRIPTION
- Require Ruby 2.7
- Drop testing with Ruby 2.6 from GitHub Actions
- Make RuboCop target Ruby 2.7
- Autocorrect Performance/MapCompact, replaceing map...compact with filter_map
