### PR TITLE
Update RuboCop and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ AllCops:
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-minitest", "~> 0.20.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"

--- a/test/base_test_helper.rb
+++ b/test/base_test_helper.rb
@@ -25,8 +25,8 @@ module BaseTestExtensions
     method = method.to_sym
     methods = klass.singleton_methods(false).map(&:to_sym)
     msg = message(msg) do
-      "Expected #{mu_pp(klass)} to define singleton method #{mu_pp(method)}, " \
-        "but only found #{mu_pp(methods)}"
+      "Expected #{mu_pp(klass)} to define singleton method #{mu_pp(method)}," \
+        " but only found #{mu_pp(methods)}"
     end
     assert_includes methods, method, msg
   end
@@ -44,8 +44,8 @@ module BaseTestExtensions
     method = method.to_sym
     methods = klass.instance_methods(false).map(&:to_sym)
     msg = message(msg) do
-      "Expected #{mu_pp(klass)} to define instance method #{mu_pp(method)}, " \
-        "but only found #{mu_pp(methods)}"
+      "Expected #{mu_pp(klass)} to define instance method #{mu_pp(method)}," \
+        " but only found #{mu_pp(methods)}"
     end
     assert_includes methods, method, msg
   end

--- a/test/gir_ffi/builders/argument_builder_test.rb
+++ b/test/gir_ffi/builders/argument_builder_test.rb
@@ -179,7 +179,7 @@ describe GirFFI::Builders::ArgumentBuilder do
 
         it "has the correct value for #post_conversion" do
           _(builder.post_conversion)
-            .must_equal ["_v2 = GIMarshallingTests::BoxedStruct.wrap_copy("\
+            .must_equal ["_v2 = GIMarshallingTests::BoxedStruct.wrap_copy(" \
                          "_v1.get_pointer(0))"]
         end
       end


### PR DESCRIPTION
- Bump RuboCop version to support LineContinuationLeadingSpace config
- Configure LineContinuationLeadingSpace cop
- Autocorrect Layout/LineContinuationSpacing
- Correct Layout/LineContinuationLeadingSpace offenses
