### PR TITLE
Fix YARD warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,6 +66,10 @@ Naming/VariableNumber:
 Performance/StartWith:
   AutoCorrect: true
 
+# Use alias_method since it is more versatile
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 # Allow and/or for control flow only
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,7 @@
 --hide-api private
 --load yard-plugin/setup.rb
+lib/ffi-gobject_introspection
+lib
 -
 *.md
 docs/*.md

--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,3 @@
---hide-api private
 --load yard-plugin/setup.rb
 lib/ffi-gobject_introspection
 lib

--- a/lib/ffi-glib/array.rb
+++ b/lib/ffi-glib/array.rb
@@ -52,7 +52,7 @@ module GLib
       Lib.g_array_get_element_size self
     end
 
-    alias element_size get_element_size
+    alias_method :element_size, :get_element_size
 
     def ==(other)
       to_a == other.to_a

--- a/lib/ffi-glib/main_loop.rb
+++ b/lib/ffi-glib/main_loop.rb
@@ -58,8 +58,8 @@ module GLib
       current_loop.quit
     end
 
-    alias run_without_thread_enabler run
-    alias run run_with_thread_enabler
+    alias_method :run_without_thread_enabler, :run
+    alias_method :run, :run_with_thread_enabler
   end
 end
 

--- a/lib/ffi-glib/variant.rb
+++ b/lib/ffi-glib/variant.rb
@@ -11,8 +11,8 @@ module GLib
       get_string_without_override.first
     end
 
-    alias get_string_without_override get_string
-    alias get_string get_string_with_override
+    alias_method :get_string_without_override, :get_string
+    alias_method :get_string, :get_string_with_override
 
     # Initializing method used in constructors. For Variant the constructing
     # functions all return floating references, so this is need to take full

--- a/lib/ffi-gobject/object.rb
+++ b/lib/ffi-gobject/object.rb
@@ -33,8 +33,8 @@ module GObject
       store_pointer ptr
     end
 
-    alias old_initialze initialize
-    alias initialize initialize_with_properties
+    alias_method :old_initialze, :initialize
+    alias_method :initialize, :initialize_with_properties
     remove_method :old_initialze
 
     def self.new(*args, &block)
@@ -43,7 +43,7 @@ module GObject
       obj
     end
 
-    alias base_initialize initialize
+    alias_method :base_initialize, :initialize
 
     private :base_initialize
 
@@ -82,7 +82,7 @@ module GObject
     setup_instance_method! "get_property"
     setup_instance_method! "set_property"
     setup_instance_method! "is_floating"
-    alias floating? is_floating
+    alias_method :floating?, :is_floating
 
     private
 

--- a/lib/ffi-gobject/value.rb
+++ b/lib/ffi-gobject/value.rb
@@ -81,7 +81,7 @@ module GObject
         send set_method, val
       end
 
-      alias value= set_value
+      alias_method :value=, :set_value
 
       def current_gtype
         struct[:g_type]

--- a/lib/ffi-gobject_introspection/i_registered_type_info.rb
+++ b/lib/ffi-gobject_introspection/i_registered_type_info.rb
@@ -16,6 +16,6 @@ module GObjectIntrospection
       Lib.g_registered_type_info_get_g_type self
     end
 
-    alias gtype g_type
+    alias_method :gtype, :g_type
   end
 end

--- a/lib/gir_ffi/ffi_ext/pointer.rb
+++ b/lib/gir_ffi/ffi_ext/pointer.rb
@@ -23,9 +23,10 @@ module GirFFI
   end
 end
 
-FFI::Pointer.prepend GirFFI::FFIExt::Pointer
+# @api private
+class FFI::Pointer # rubocop:disable Style/ClassAndModuleChildren
+  prepend GirFFI::FFIExt::Pointer
 
-FFI::Pointer.class_eval do
   size_t_getter = case FFI.type_size(:size_t)
                   when 4
                     :get_uint32

--- a/lib/gir_ffi/ffi_ext/pointer.rb
+++ b/lib/gir_ffi/ffi_ext/pointer.rb
@@ -27,13 +27,17 @@ end
 class FFI::Pointer # rubocop:disable Style/ClassAndModuleChildren
   prepend GirFFI::FFIExt::Pointer
 
-  size_t_getter = case FFI.type_size(:size_t)
-                  when 4
-                    :get_uint32
-                  when 8
-                    :get_uint64
-                  end
+  size_t_getter =
+    case (size = FFI.type_size(:size_t))
+    when 4
+      :get_uint32
+    when 8
+      :get_uint64
+    else
+      raise NotImplementedError, "Don't know how to handle size_t types of size #{size}"
+    end
 
   alias_method :get_size_t, size_t_getter
+
   alias_method :get_gtype, :get_size_t
 end

--- a/lib/gir_ffi/ffi_ext/pointer.rb
+++ b/lib/gir_ffi/ffi_ext/pointer.rb
@@ -4,6 +4,25 @@ module GirFFI
   module FFIExt
     # Extensions to FFI::Pointer
     module Pointer
+      def self.prepended(base)
+        base.class_eval do
+          size_t_getter =
+            case (size = FFI.type_size(:size_t))
+            when 4
+              :get_uint32
+            when 8
+              :get_uint64
+            else
+              raise NotImplementedError,
+                    "Don't know how to handle size_t types of size #{size}"
+            end
+
+          alias_method :get_size_t, size_t_getter
+
+          alias_method :get_gtype, :get_size_t
+        end
+      end
+
       def to_ptr
         self
       end
@@ -26,18 +45,4 @@ end
 # @api private
 class FFI::Pointer # rubocop:disable Style/ClassAndModuleChildren
   prepend GirFFI::FFIExt::Pointer
-
-  size_t_getter =
-    case (size = FFI.type_size(:size_t))
-    when 4
-      :get_uint32
-    when 8
-      :get_uint64
-    else
-      raise NotImplementedError, "Don't know how to handle size_t types of size #{size}"
-    end
-
-  alias_method :get_size_t, size_t_getter
-
-  alias_method :get_gtype, :get_size_t
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -109,11 +109,11 @@ class Listener
     @class_stack << [tag, obj_name]
   end
 
-  alias start_bitfield start_type
-  alias start_enumeration start_type
-  alias start_interface start_type
-  alias start_record start_type
-  alias start_union start_type
+  alias_method :start_bitfield, :start_type
+  alias_method :start_enumeration, :start_type
+  alias_method :start_interface, :start_type
+  alias_method :start_record, :start_type
+  alias_method :start_union, :start_type
 
   def start_constructor(_tag, obj_name, _attrs)
     emit_indented 4, "it \"creates an instance using ##{obj_name}\" do"
@@ -136,7 +136,7 @@ class Listener
     emit_indented 2, "#{spaces}it \"has a working #{tag} ##{obj_name}\" do"
   end
 
-  alias start_method start_function
+  alias_method :start_method, :start_function
 
   def start_member(_tag, obj_name, _attrs)
     emit_indented 4, "it \"has the member :#{obj_name}\" do"
@@ -183,12 +183,12 @@ class Listener
     emit_indented 2, "end" unless @class_stack.any?
   end
 
-  alias end_record end_object
-  alias end_class end_object
-  alias end_enumeration end_object
-  alias end_bitfield end_object
-  alias end_interface end_object
-  alias end_union end_object
+  alias_method :end_record, :end_object
+  alias_method :end_class, :end_object
+  alias_method :end_enumeration, :end_object
+  alias_method :end_bitfield, :end_object
+  alias_method :end_interface, :end_object
+  alias_method :end_union, :end_object
 
   def end_function
     if @class_stack.any?
@@ -198,11 +198,11 @@ class Listener
     end
   end
 
-  alias end_constructor end_function
-  alias end_method end_function
-  alias end_member end_function
-  alias end_property end_function
-  alias end_signal end_function
+  alias_method :end_constructor, :end_function
+  alias_method :end_method, :end_function
+  alias_method :end_member, :end_function
+  alias_method :end_property, :end_function
+  alias_method :end_signal, :end_function
 
   def end_field
     emit_indented 4, "end" if current_object_type != "class"


### PR DESCRIPTION
- Improve YARD file reading order
- Let YARD know FFI::Pointer exists
- Prefer alias_method over alias
- Guard against unsupported size_t type sizes
- Show private API in generated documentation
- Move method alias setup code into FFIExt::Pointer.prepended
