### PR TITLE
Update RuboCop and its configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ inherit_from: .rubocop_todo.yml
 inherit_mode:
   merge:
     - Exclude
+    - CountAsOne
 
 require:
   - rubocop-minitest
@@ -62,6 +63,11 @@ Metrics/BlockLength:
     - 'test/**/*'
     - 'tasks/*.rake'
     - '*.gemspec'
+
+# Count certain literals as only one line of code
+Metrics/MethodLength:
+  CountAsOne:
+    - heredoc
 
 # Allow semantic variation in and/or external determination of symbols
 Naming/VariableNumber:

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop", "~> 1.54"
   spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.18"


### PR DESCRIPTION
Updates RuboCop and configures the MethodLength cop to only count heredocs as a single line. This silences new MethodLength offenses that appeared because MethodLength's line counting was changed.

- Bump RuboCop version
- Count heredocs as only one line for the MethodLength cop
