### PR TITLE
Avoid potentially accessing data after deallocation in unref spec

### DIFF
--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1453,9 +1453,10 @@ describe Regress do
     end
 
     it "has a working method #unref" do
-      _(base_struct[:refcount]).must_equal 1
+      derived_instance.ref
+      _(base_struct[:refcount]).must_equal 2
       derived_instance.unref
-      _(base_struct[:refcount]).must_equal 0
+      _(base_struct[:refcount]).must_equal 1
     end
   end
 


### PR DESCRIPTION
After the last `#unref`, `derived_instance`'s struct data may be deallocated, so fetching its refcount field is unreliable. By first increasing the refcount, checking that `#unref` decreases the refcount can be tested reliably.
