### PR TITLE
Require at least ffi 1.16.3 to avoid 'Can't modify frozen Hash' error

### DIFF
--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["DESIGN.md", "Changelog.md", "README.md", "TODO.md"]
 
-  spec.add_runtime_dependency "ffi", "~> 1.8"
+  spec.add_runtime_dependency "ffi", ["~> 1.16", ">= 1.16.3"]
   spec.add_runtime_dependency "ffi-bit_masks", "~> 0.1.1"
 
   spec.add_development_dependency "aruba", "~> 2.0"


### PR DESCRIPTION
See https://github.com/ffi/ffi/issues/1056.
