### PR TITLE
Handle new RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,6 +108,10 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
+# Disable to allow free choice
+Style/SuperWithArgsParentheses:
+  Enabled: false
+
 # Prefer symbols to look like symbols
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.56"
+  spec.add_development_dependency "rubocop", "~> 1.58"
   spec.add_development_dependency "rubocop-minitest", "~> 0.33.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.19"

--- a/lib/ffi-gobject_introspection/lib.rb
+++ b/lib/ffi-gobject_introspection/lib.rb
@@ -258,7 +258,7 @@ module GObjectIntrospection
 
     # Union type representing an argument value
     class GIArgument < FFI::Union
-      signed_size_t = "int#{FFI.type_size(:size_t) * 8}".to_sym
+      signed_size_t = :"int#{FFI.type_size(:size_t) * 8}"
 
       layout :v_boolean, :int,
              :v_int8, :int8,

--- a/lib/gir_ffi/builders/argument_builder.rb
+++ b/lib/gir_ffi/builders/argument_builder.rb
@@ -172,7 +172,7 @@ module GirFFI
       end
 
       def has_ingoing_component?
-        (direction == :inout || direction == :in)
+        direction == :inout || direction == :in
       end
 
       def array_length_assignment

--- a/lib/gir_ffi/type_map.rb
+++ b/lib/gir_ffi/type_map.rb
@@ -7,7 +7,7 @@ module GirFFI
   # Maps GObject type tags and type specification to types FFI can handle.
   module TypeMap
     sz = FFI.type_size(:size_t) * 8
-    gsize_type = "uint#{sz}".to_sym
+    gsize_type = :"uint#{sz}"
 
     TAG_TYPE_MAP = {
       enum: :int32,

--- a/test/introspection_test_helper.rb
+++ b/test/introspection_test_helper.rb
@@ -78,6 +78,8 @@ module IntrospectionTestExtensions
 
   LATEST_VERSION = VERSION_GUARDS.keys.first
 
+  # RuboCop 1.58.0 has a false positive here
+  # rubocop:disable Style/HashEachMethods
   def calculate_version
     VERSION_GUARDS.each do |version, (namespace, class_or_function, method_name)|
       result = if method_name
@@ -90,6 +92,7 @@ module IntrospectionTestExtensions
 
     "1.56.0" # Minimum supported version
   end
+  # rubocop:enable Style/HashEachMethods
 end
 
 Minitest::Test.include IntrospectionTestExtensions


### PR DESCRIPTION
- Autocorrect Style/RedundantParentheses
- Autocorrect Lint/SymbolConversion
- Update minimum rubocop dependency
- Do not force parentheses only on super
- Prevent Style/HashEachMethods false positive
