### PR TITLE
Update RuboCop dependencies and fix new offenses

### DIFF
--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,9 +40,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.58"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.33.0"
+  spec.add_development_dependency "rubocop", "~> 1.59"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.34.1"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
-  spec.add_development_dependency "rubocop-performance", "~> 1.19"
+  spec.add_development_dependency "rubocop-performance", "~> 1.20"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/lib/gir_ffi/array_element_convertor.rb
+++ b/lib/gir_ffi/array_element_convertor.rb
@@ -32,7 +32,7 @@ module GirFFI
       when Module
         value_ffi_type.get_value_from_pointer(pointer, 0)
       when Symbol
-        pointer.send("get_#{value_ffi_type}", 0)
+        pointer.send(:"get_#{value_ffi_type}", 0)
       else
         raise NotImplementedError
       end

--- a/lib/gir_ffi/builders/user_defined_builder.rb
+++ b/lib/gir_ffi/builders/user_defined_builder.rb
@@ -128,7 +128,7 @@ module GirFFI
 
       def property_setter_func
         setter = proc do |object, _property_id, value, pspec|
-          object.send("#{pspec.accessor_name}=", value.get_value)
+          object.send(:"#{pspec.accessor_name}=", value.get_value)
         end
         GObject::ObjectSetPropertyFunc.from setter
       end

--- a/lib/gir_ffi/in_pointer.rb
+++ b/lib/gir_ffi/in_pointer.rb
@@ -57,7 +57,7 @@ module GirFFI
         ffi_type = TypeMap.type_specification_to_ffi_type type
         FFI::MemoryPointer.new(ffi_type).tap do |block|
           block.autorelease = false
-          block.send "put_#{ffi_type}", 0, value
+          block.send :"put_#{ffi_type}", 0, value
         end
       end
 
@@ -137,7 +137,7 @@ module GirFFI
         type_size = FFI.type_size(ffi_type)
         FFI::MemoryPointer.new(type_size * (ary.length + 1)).tap do |block|
           block.autorelease = false
-          block.send "put_array_of_#{ffi_type}", 0, ary
+          block.send :"put_array_of_#{ffi_type}", 0, ary
         end
       end
     end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -37,7 +37,7 @@ class Listener
     obj_name = attrs["name"]
     case tag
     when *HANDLED_TAGS
-      send "start_#{tag}", tag, obj_name, attrs
+      send :"start_#{tag}", tag, obj_name, attrs
     when "glib:signal"
       start_signal(tag, obj_name, attrs)
     when *SILENT_TAGS
@@ -54,7 +54,7 @@ class Listener
 
     case tag
     when *HANDLED_TAGS
-      send "end_#{tag}"
+      send :"end_#{tag}"
     when "glib:signal"
       end_signal
     end

--- a/test/gir_ffi/builder_test.rb
+++ b/test/gir_ffi/builder_test.rb
@@ -66,7 +66,7 @@ describe GirFFI::Builder do
 
     it "returns the class for user-defined types" do
       klass = Class.new GIMarshallingTests::OverridesObject
-      Object.const_set "Derived#{Sequence.next}", klass
+      Object.const_set :"Derived#{Sequence.next}", klass
       gtype = GirFFI.define_type klass
 
       found_klass = GirFFI::Builder.build_by_gtype gtype
@@ -75,7 +75,7 @@ describe GirFFI::Builder do
 
     it "returns the class for user-defined types not derived from GObject" do
       klass = Class.new Regress::TestFundamentalObject
-      Object.const_set "Derived#{Sequence.next}", klass
+      Object.const_set :"Derived#{Sequence.next}", klass
       gtype = GirFFI.define_type klass
 
       found_klass = GirFFI::Builder.build_by_gtype gtype

--- a/test/gir_ffi/builders/user_defined_builder_test.rb
+++ b/test/gir_ffi/builders/user_defined_builder_test.rb
@@ -8,7 +8,7 @@ GirFFI.setup :Regress
 describe GirFFI::Builders::UserDefinedBuilder do
   let(:base_class) { GIMarshallingTests::Object }
   let(:derived_class) do
-    Object.const_set("DerivedClass#{Sequence.next}", Class.new(base_class))
+    Object.const_set(:"DerivedClass#{Sequence.next}", Class.new(base_class))
   end
   let(:builder) { GirFFI::Builders::UserDefinedBuilder.new info }
   let(:info) { derived_class.gir_info }
@@ -412,7 +412,7 @@ describe GirFFI::Builders::UserDefinedBuilder do
         GObject.type_query(parent_class.gtype).instance_size
       end
       let(:derived_class) do
-        Object.const_set("DerivedClass#{Sequence.next}", Class.new(parent_class))
+        Object.const_set(:"DerivedClass#{Sequence.next}", Class.new(parent_class))
       end
       before do
         derived_class

--- a/test/gir_ffi/core_test.rb
+++ b/test/gir_ffi/core_test.rb
@@ -30,7 +30,7 @@ describe GirFFI::Core do
     describe "with a class with no extra properties added" do
       before do
         @klass = Class.new GIMarshallingTests::OverridesObject
-        Object.const_set "DerivedA#{Sequence.next}", @klass
+        Object.const_set :"DerivedA#{Sequence.next}", @klass
         @gtype = GirFFI.define_type @klass
       end
 
@@ -68,7 +68,7 @@ describe GirFFI::Core do
                                                   10, 20, 15,
                                                   3)
         end
-        Object.const_set "DerivedB#{Sequence.next}", @klass
+        Object.const_set :"DerivedB#{Sequence.next}", @klass
         @gtype = GirFFI.define_type @klass
       end
 
@@ -91,7 +91,7 @@ describe GirFFI::Core do
     describe "with a type that is not a GObject" do
       let(:klass) { Class.new GObject::RubyClosure }
       before do
-        Object.const_set "DerivedB#{Sequence.next}", klass
+        Object.const_set :"DerivedB#{Sequence.next}", klass
       end
 
       it "raises a friendly error" do

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -9,7 +9,7 @@ GirFFI.setup :GIMarshallingTests
 # Tests generated methods and functions in the GIMarshallingTests namespace.
 describe GIMarshallingTests do
   let(:derived_klass) do
-    Object.const_set("DerivedClass#{Sequence.next}",
+    Object.const_set(:"DerivedClass#{Sequence.next}",
                      Class.new(GIMarshallingTests::Object))
   end
 

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -927,7 +927,7 @@ describe Regress do
 
   describe "Regress::FooSubInterface" do
     let(:derived_klass) do
-      Object.const_set("DerivedClass#{Sequence.next}",
+      Object.const_set(:"DerivedClass#{Sequence.next}",
                        Class.new(Regress::FooObject))
     end
 

--- a/test/integration/generated_warnlib_test.rb
+++ b/test/integration/generated_warnlib_test.rb
@@ -7,7 +7,7 @@ GirFFI.setup :WarnLib
 describe WarnLib do
   describe "WarnLib::Whatever" do
     let(:derived_klass) do
-      Object.const_set("DerivedClass#{Sequence.next}", Class.new(GObject::Object))
+      Object.const_set(:"DerivedClass#{Sequence.next}", Class.new(GObject::Object))
     end
 
     before do

--- a/test/introspection_test_helper.rb
+++ b/test/introspection_test_helper.rb
@@ -78,8 +78,6 @@ module IntrospectionTestExtensions
 
   LATEST_VERSION = VERSION_GUARDS.keys.first
 
-  # RuboCop 1.58.0 has a false positive here
-  # rubocop:disable Style/HashEachMethods
   def calculate_version
     VERSION_GUARDS.each do |version, (namespace, class_or_function, method_name)|
       result = if method_name
@@ -92,7 +90,6 @@ module IntrospectionTestExtensions
 
     "1.56.0" # Minimum supported version
   end
-  # rubocop:enable Style/HashEachMethods
 end
 
 Minitest::Test.include IntrospectionTestExtensions


### PR DESCRIPTION
- Update rubocop dependencies
- Autocorrect Performance/StringIdentifierArgument
- Remove obsolete disabling of Style/HashEachMethods
