### PR TITLE
Handle latest RuboCop offenses

### DIFF
--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.59"
+  spec.add_development_dependency "rubocop", "~> 1.63"
   spec.add_development_dependency "rubocop-minitest", "~> 0.35.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.20"

--- a/test/ffi-glib/array_test.rb
+++ b/test/ffi-glib/array_test.rb
@@ -31,7 +31,7 @@ describe GLib::Array do
 
     it "iterates over the values" do
       a = []
-      @arr.each { |v| a << v }
+      @arr.each { |v| a << v } # rubocop:disable Style/MapIntoArray
 
       assert_equal [1, 2, 3], a
     end

--- a/test/ffi-glib/ptr_array_test.rb
+++ b/test/ffi-glib/ptr_array_test.rb
@@ -28,7 +28,7 @@ describe GLib::PtrArray do
       GLib::PtrArray.add arr, "test3"
 
       a = []
-      arr.each { |v| a << v }
+      arr.each { |v| a << v } # rubocop:disable Style/MapIntoArray
 
       assert_equal %w[test1 test2 test3], a
     end

--- a/test/ffi-gobject_introspection/strv_test.rb
+++ b/test/ffi-gobject_introspection/strv_test.rb
@@ -28,7 +28,7 @@ describe GObjectIntrospection::Strv do
 
       strv = GObjectIntrospection::Strv.new block
       arr = []
-      strv.each do |str|
+      strv.each do |str| # rubocop:disable Style/MapIntoArray
         arr << str
       end
 

--- a/test/gir_ffi/sized_array_test.rb
+++ b/test/gir_ffi/sized_array_test.rb
@@ -31,7 +31,7 @@ describe GirFFI::SizedArray do
 
       sarr = GirFFI::SizedArray.new :utf8, 3, block
       arr = []
-      sarr.each do |str|
+      sarr.each do |str| # rubocop:disable Style/MapIntoArray
         arr << str
       end
 

--- a/test/gir_ffi/zero_terminated_test.rb
+++ b/test/gir_ffi/zero_terminated_test.rb
@@ -43,7 +43,7 @@ describe GirFFI::ZeroTerminated do
     it "yields each element" do
       zt = GirFFI::ZeroTerminated.from :int32, [1, 2, 3]
       arr = []
-      zt.each do |int|
+      zt.each do |int| # rubocop:disable Style/MapIntoArray
         arr << int
       end
       _(arr).must_equal [1, 2, 3]
@@ -60,7 +60,7 @@ describe GirFFI::ZeroTerminated do
     it "works for :int8" do
       zt = GirFFI::ZeroTerminated.from :int8, [1, 2, 3]
       arr = []
-      zt.each do |int|
+      zt.each do |int| # rubocop:disable Style/MapIntoArray
         arr << int
       end
       _(arr).must_equal [1, 2, 3]


### PR DESCRIPTION
- **Bump rubocop dependency version so Style/MapIntoArray is available**
- **Disable Style/MapIntoArray cop in specs for #each methods**
