### PR TITLE
Load gobject-2.0 library in a way that does not require dev package

### DIFF
--- a/lib/ffi-gobject_introspection/gobject_type_init.rb
+++ b/lib/ffi-gobject_introspection/gobject_type_init.rb
@@ -12,7 +12,7 @@ module GObjectIntrospection
     # Module for attaching g_type_init from the gobject library.
     module Lib
       extend FFI::Library
-      ffi_lib "gobject-2.0"
+      ffi_lib "gobject-2.0.so.0"
       attach_function :g_type_init, [], :void
     end
   end

--- a/lib/gir_ffi-base/gobject/lib.rb
+++ b/lib/gir_ffi-base/gobject/lib.rb
@@ -8,7 +8,7 @@ module GObject
     extend FFI::Library
     extend FFI::BitMasks
 
-    ffi_lib "gobject-2.0"
+    ffi_lib "gobject-2.0.so.0"
 
     attach_function :g_type_from_name, [:string], :size_t
     attach_function :g_type_fundamental, [:size_t], :size_t


### PR DESCRIPTION
On, e.g., Debian, only the development package contains the gobject-2.0.so link. To load the library with only the library package installed, we specify the so version.
