### PR TITLE
Update tests for compatibility with GObjectIntrospection 1.81.2

### DIFF
--- a/lib/gir_ffi/builders/argument_builder_collection.rb
+++ b/lib/gir_ffi/builders/argument_builder_collection.rb
@@ -76,6 +76,7 @@ module GirFFI
         @base_argument_builders.each do |bldr|
           if (idx = bldr.closure_idx) >= 0
             target_bldr = @base_argument_builders[idx]
+            # NOTE: Only needed for GObjectIntrospection versions 1.67.1 through 1.80.1
             unless target_bldr.specialized_type_tag == :void
               target_bldr, bldr = bldr, target_bldr
             end

--- a/test/ffi-gobject_introspection/i_type_info_test.rb
+++ b/test/ffi-gobject_introspection/i_type_info_test.rb
@@ -21,6 +21,8 @@ describe GObjectIntrospection::ITypeInfo do
       let(:type_info) { argument_info.argument_type }
 
       it "returns an IUnresolvableInfo object" do
+        # TODO: Find another way to test this
+        skip_above "1.80.1", "This function is no longer introspectable"
         result = type_info.interface
         _(result.info_type).must_equal :unresolved
         _(result).must_be_kind_of GObjectIntrospection::IUnresolvedInfo

--- a/test/gir_ffi/builders/function_builder_test.rb
+++ b/test/gir_ffi/builders/function_builder_test.rb
@@ -194,12 +194,17 @@ describe GirFFI::Builders::FunctionBuilder do
     # NOTE: The closure annotation should normally point at the user data, but
     # for this function, from gobject-introspection 1.67.1, the annotation points
     # from the user data to the closure.
+    #
+    # Starting from gobject-introspection 1.80.1, invalid closure info is
+    # warned about and dropped. To make this function work again, we have to
+    # wait for GObject to be updated.
     describe "for functions that have swapped closure annotation" do
       let(:function_info) do
         get_introspection_data "GObject", "signal_handlers_unblock_matched"
       end
       it "builds a correct definition" do
         skip_below "1.67.1"
+        skip_above "1.80.1", "Closure info is no longer emitted for invalid annotations"
         _(code).must_equal <<~CODE
           def self.signal_handlers_unblock_matched(instance, mask, signal_id, detail, closure = nil, func = nil)
             _v1 = GObject::Object.from(instance)

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -3014,6 +3014,7 @@ describe GIMarshallingTests do
   end
 
   it "has a working function #pointer_struct_get_type" do
+    skip_above "1.80.1", "This get_type ¸function is no longer exposed separately"
     res = GIMarshallingTests.pointer_struct_get_type
     gtype = GObject.type_from_name "GIMarshallingTestsPointerStruct"
 

--- a/test/integration/generated_gobject_test.rb
+++ b/test/integration/generated_gobject_test.rb
@@ -16,6 +16,7 @@ describe GObject do
 
   describe ".signal_set_va_marshaller" do
     it "can be set up" do
+      skip_above "1.80.1", "This function is no longer introspectable"
       result = GObject.setup_method "signal_set_va_marshaller"
       _(result).must_equal true
     end

--- a/test/introspection_test_helper.rb
+++ b/test/introspection_test_helper.rb
@@ -53,10 +53,20 @@ module IntrospectionTestExtensions
 
   def skip_below(introduction_version)
     if introduction_version > LATEST_VERSION
-      raise "Version #{introduction_version} is too new and would always be skipped"
+      raise "Version #{introduction_version} is too new causing test to always be skipped"
     end
 
-    skip "Introduced in #{introduction_version}" if introduction_version > version
+    skip "Introduced in #{introduction_version}" if version < introduction_version
+  end
+
+  def skip_above(last_available_version, message = nil)
+    if last_available_version < EARLIEST_VERSION
+      raise "Version #{last_available_version} is too old causing test to always be skipped"
+    end
+
+    if version > last_available_version
+      skip message || "Removed after #{last_available_version}"
+    end
   end
 
   def version
@@ -64,6 +74,8 @@ module IntrospectionTestExtensions
   end
 
   VERSION_GUARDS = {
+    "1.81.2" => %w[GIMarshallingTests dev_t_in],
+    "1.80.1" => %w[Everything const_return_off_t],
     "1.71.0" => %w[Regress TestFundamentalObjectNoGetSetFunc],
     "1.69.0" => %w[Regress TestObj get_string],
     "1.67.1" => %w[GIMarshallingTests SignalsObject],
@@ -77,6 +89,7 @@ module IntrospectionTestExtensions
   }.freeze
 
   LATEST_VERSION = VERSION_GUARDS.keys.first
+  EARLIEST_VERSION = "1.56.0"
 
   def calculate_version
     VERSION_GUARDS.each do |version, (namespace, class_or_function, method_name)|
@@ -88,7 +101,7 @@ module IntrospectionTestExtensions
       return version if result
     end
 
-    "1.56.0" # Minimum supported version
+    EARLIEST_VERSION # Minimum supported version
   end
 end
 


### PR DESCRIPTION
- Skip tests using functions that are no longer introspectable
- Skip test for swapped closure data handling after GObjectIntrospection version 1.80.1
