### PR TITLE
Update RuboCop dependencies and configuration and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,12 @@ inherit_mode:
     - Exclude
     - CountAsOne
 
-require:
+plugins:
   - rubocop-minitest
-  - rubocop-packaging
   - rubocop-performance
+
+require:
+  - rubocop-packaging
 
 AllCops:
   Exclude:

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -42,9 +42,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rexml", "~> 3.0"
   spec.add_development_dependency "rspec-mocks", "~> 3.5"
-  spec.add_development_dependency "rubocop", "~> 1.63"
+  spec.add_development_dependency "rubocop", "~> 1.73"
   spec.add_development_dependency "rubocop-minitest", "~> 0.37.1"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
-  spec.add_development_dependency "rubocop-performance", "~> 1.20"
+  spec.add_development_dependency "rubocop-performance", "~> 1.24"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/lib/gir_ffi/boolean.rb
+++ b/lib/gir_ffi/boolean.rb
@@ -8,15 +8,16 @@ module GirFFI
     extend FFI::DataConverter
     native_type FFI::Type::INT
 
-    FROM_NATIVE = { 0 => false, 1 => true }.freeze
-    TO_NATIVE = FROM_NATIVE.invert
+    NATIVE_TRUE = 1
+    NATIVE_FALSE = 0
+    FROM_NATIVE = { NATIVE_FALSE => false, NATIVE_TRUE => true }.freeze
 
     def self.from_native(value, _context)
       FROM_NATIVE.fetch(value)
     end
 
     def self.to_native(value, _context)
-      TO_NATIVE.fetch(value ? true : false)
+      value ? NATIVE_TRUE : NATIVE_FALSE
     end
 
     def self.size


### PR DESCRIPTION
- Bump rubocop gem dependency versions to ensure plugin support
- Use the new rubocop plugins configuration syntax
- Simplify GirFFI::Boolean.to_native implementation
