### PR TITLE
Allow specifying signals as symbols

### DIFF
--- a/lib/ffi-gobject.rb
+++ b/lib/ffi-gobject.rb
@@ -36,6 +36,7 @@ module GObject
   end
 
   def self.signal_emit(object, detailed_signal, *args)
+    detailed_signal = detailed_signal.to_s.tr("_", "-") if detailed_signal.is_a?(Symbol)
     signal, detail = detailed_signal.split("::")
     signal_id = signal_lookup_from_instance signal, object
     detail_quark = GLib.quark_from_string(detail)
@@ -50,6 +51,7 @@ module GObject
   def self.signal_connect(object, detailed_signal, data = nil, after = false, &block)
     block or raise ArgumentError, "Block needed"
 
+    detailed_signal = detailed_signal.to_s.tr("_", "-") if detailed_signal.is_a?(Symbol)
     signal_name, = detailed_signal.split("::")
     sig_info = object.class.find_signal signal_name
 

--- a/test/ffi-gobject_test.rb
+++ b/test/ffi-gobject_test.rb
@@ -73,6 +73,15 @@ describe GObject do
       _(proc { GObject.signal_emit obj, "sig-with-inout-int", 0 })
         .must_raise NotImplementedError
     end
+
+    it "allows specifying the signal as a symbol" do
+      a = 1
+      o = Regress::TestSubObj.new
+      GObject.signal_connect(o, "sig-with-uint64-prop") { |_, uint64, _| a = uint64 }
+      GObject.signal_emit o, :sig_with_uint64_prop, 0xffff_ffff_ffff_ffff
+
+      _(a).must_equal 0xffff_ffff_ffff_ffff
+    end
   end
 
   describe "::signal_connect" do
@@ -158,6 +167,15 @@ describe GObject do
         assert_instance_of Regress::TestSimpleBoxedA, @b
         assert_equal 23, @b.some_int
       end
+    end
+
+    it "allows specifying the signal as a symbol" do
+      a = 1
+      o = Regress::TestSubObj.new
+      GObject.signal_connect(o, :sig_with_uint64_prop) { |_, uint64, _| a = uint64 }
+      GObject.signal_emit o, "sig-with-uint64-prop", 0xffff_ffff_ffff_ffff
+
+      _(a).must_equal 0xffff_ffff_ffff_ffff
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/mvz/gir_ffi-gtk/issues/104.

- Support using symbols as signal names
- Extract signal name handling code to a private method
