### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
   Exclude:
     - 'examples/*'
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gir_ffi.gemspec
+++ b/gir_ffi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/ruby-gir-ffi"
 
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi"

--- a/lib/ffi-gobject/ruby_closure.rb
+++ b/lib/ffi-gobject/ruby_closure.rb
@@ -41,8 +41,8 @@ module GObject
 
     # @api private
     # TODO: Re-structure so invoke_block can become a private method
-    def invoke_block(*args)
-      block.call(*args)
+    def invoke_block(*)
+      block.call(*)
     end
 
     private

--- a/lib/gir_ffi/callback_base.rb
+++ b/lib/gir_ffi/callback_base.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "gir_ffi/type_base"
-require "set"
 
 module GirFFI
   # Base module for callbacks and vfuncs.

--- a/lib/gir_ffi/enum_base.rb
+++ b/lib/gir_ffi/enum_base.rb
@@ -11,12 +11,12 @@ module GirFFI
       self::Enum.native_type
     end
 
-    def to_native(*args)
-      self::Enum.to_native(*args)
+    def to_native(*)
+      self::Enum.to_native(*)
     end
 
-    def from_native(*args)
-      self::Enum.from_native(*args)
+    def from_native(*)
+      self::Enum.from_native(*)
     end
 
     def [](arg)


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Autocorrect new RuboCop offenses**
- **Remove Ruby 3.1 from the CI matrix**
