### PR TITLE
Distinguish null pointer from empty array when wrapping GStrv pointer

### DIFF
--- a/lib/ffi-gobject_introspection/strv.rb
+++ b/lib/ffi-gobject_introspection/strv.rb
@@ -28,7 +28,7 @@ module GObjectIntrospection
     end
 
     def self.wrap(ptr)
-      new ptr
+      new ptr unless ptr.null?
     end
 
     private

--- a/test/ffi-gobject_introspection/strv_test.rb
+++ b/test/ffi-gobject_introspection/strv_test.rb
@@ -11,10 +11,17 @@ describe GObjectIntrospection::Strv do
 
   describe "::wrap" do
     it "takes a pointer and returns a GObjectIntrospection::Strv wrapping it" do
-      strv = GObjectIntrospection::Strv.wrap :some_pointer
+      ptr = instance_double FFI::Pointer, null?: false
+      strv = GObjectIntrospection::Strv.wrap ptr
 
       assert_instance_of GObjectIntrospection::Strv, strv
-      assert_equal :some_pointer, strv.to_ptr
+      assert_equal ptr, strv.to_ptr
+    end
+
+    it "returns nil when passed a null pointer" do
+      strv = GObjectIntrospection::Strv.wrap FFI::Pointer::NULL
+
+      _(strv).must_be_nil
     end
   end
 
@@ -33,6 +40,17 @@ describe GObjectIntrospection::Strv do
       end
 
       assert_equal %w[one two three], arr
+    end
+
+    it "yields zero times for a Strv wrapping an empty block of strings" do
+      ptrs = [nil]
+      block = FFI::MemoryPointer.new(:pointer, ptrs.length)
+      block.write_array_of_pointer ptrs
+      strv = GObjectIntrospection::Strv.new block
+
+      strv.each do |_str|
+        flunk
+      end
     end
 
     it "yields zero times for a Strv wrapping a null pointer" do

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -38,7 +38,7 @@ describe GIMarshallingTests do
     end
 
     it "has a writable field g_strv" do
-      _(instance.g_strv).must_be :==, []
+      _(instance.g_strv).must_be_nil
       instance.g_strv = %w[foo bar]
 
       _(instance.g_strv).must_be :==, %w[foo bar]
@@ -1971,11 +1971,11 @@ describe GIMarshallingTests do
 
     describe "its 'some-strv' property" do
       it "can be retrieved with #get_property" do
-        _(instance.get_property("some-strv")).must_be :==, []
+        _(instance.get_property("some-strv")).must_be_nil
       end
 
       it "can be retrieved with #some_strv" do
-        _(instance.some_strv).must_be :==, []
+        _(instance.some_strv).must_be_nil
       end
 
       it "can be set with #set_property" do
@@ -2886,7 +2886,7 @@ describe GIMarshallingTests do
   it "has a working function #array_zero_terminated_return_null" do
     res = GIMarshallingTests.array_zero_terminated_return_null
 
-    _(res).must_be :==, []
+    _(res).must_be_nil
   end
 
   it "has a working function #array_zero_terminated_return_struct" do


### PR DESCRIPTION
Previously, wrapping a null pointer returned a Strv object behaving like an empty array, while wrapping a pointer to a null pointer had the same result. Conceptually, these cases are different and the result in Ruby should be different as well.
