### PR TITLE
Use ArrayElementConvertor to convert elements of zero-terminated array

### DIFF
--- a/lib/gir_ffi/zero_terminated.rb
+++ b/lib/gir_ffi/zero_terminated.rb
@@ -30,7 +30,7 @@ module GirFFI
       offset = 0
       while (val = read_value(offset))
         offset += ffi_type_size
-        yield wrap_value(val)
+        yield val
       end
     end
 
@@ -41,34 +41,8 @@ module GirFFI
     private
 
     def read_value(offset)
-      val = fetch_value(offset)
+      val = ArrayElementConvertor.new(element_type, @ptr + offset).to_ruby_value
       val unless null_value? val
-    end
-
-    def getter_method
-      @getter_method ||= "get_#{ffi_type}"
-    end
-
-    def fetch_value(offset)
-      case ffi_type
-      when Module
-        ffi_type.get_value_from_pointer(@ptr, offset)
-      when Symbol
-        @ptr.send(getter_method, offset)
-      else
-        raise NotImplementedError
-      end
-    end
-
-    def wrap_value(val)
-      case element_type
-      when Array
-        element_type.last.wrap val
-      when Class
-        element_type.wrap val
-      else
-        val
-      end
     end
 
     def ffi_type
@@ -82,11 +56,11 @@ module GirFFI
     def null_check_strategy
       @null_check_strategy ||=
         if ffi_type == :pointer
-          :pointer
+          :nil
         elsif ffi_type.is_a? Symbol
           :numeric
         elsif ffi_type < GirFFI::ClassBase # rubocop:disable Lint/DuplicateBranch
-          :pointer
+          :nil
         elsif ffi_type.singleton_class.include? GirFFI::EnumBase
           :enum
         end
@@ -94,10 +68,10 @@ module GirFFI
 
     def null_value?(val)
       case null_check_strategy
-      when :pointer
-        val.null?
       when :enum
         ffi_type.to_native(val, nil) == 0
+      when :nil
+        val.nil?
       else
         val == 0
       end

--- a/test/integration/generated_gimarshallingtests_test.rb
+++ b/test/integration/generated_gimarshallingtests_test.rb
@@ -5399,62 +5399,94 @@ describe GIMarshallingTests do
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_container_in" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_container_in [
+      %w[0 1 2], %w[3 4 5], %w[6 7 8]
+    ]
+    pass
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_container_inout" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_container_inout [
+      %w[0 1 2], %w[3 4 5], %w[6 7 8]
+    ]
+
+    _(result.map(&:to_a))
+      .must_equal [%w[-1 0 1 2], %w[-1 3 4 5], %w[-1 6 7 8], %w[-1 9 10 11]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_container_out" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_container_out
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_container_return" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_container_return
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_full_in" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    GIMarshallingTests
+      .zero_terminated_array_of_gstrv_transfer_full_in [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
+    pass
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_full_inout" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests
+      .zero_terminated_array_of_gstrv_transfer_full_inout [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
+
+    _(result.map(&:to_a))
+      .must_equal [%w[-1 0 1 2], %w[-1 3 4 5], %w[-1 6 7 8], %w[-1 9 10 11]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_full_out" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_full_out
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_full_return" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_full_return
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_none_in" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    GIMarshallingTests
+      .zero_terminated_array_of_gstrv_transfer_none_in [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
+    pass
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_none_inout" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests
+      .zero_terminated_array_of_gstrv_transfer_none_inout [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
+
+    _(result.map(&:to_a))
+      .must_equal [%w[-1 0 1 2], %w[-1 3 4 5], %w[-1 6 7 8], %w[-1 9 10 11]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_none_out" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_none_out
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_of_gstrv_transfer_none_return" do
     skip_below "1.83.2"
-    skip "Needs testing"
+    result = GIMarshallingTests.zero_terminated_array_of_gstrv_transfer_none_return
+
+    _(result.map(&:to_a)).must_equal [%w[0 1 2], %w[3 4 5], %w[6 7 8]]
   end
 
   it "has a working function #zero_terminated_array_utf8_container_in" do


### PR DESCRIPTION
This makes the conversion of elements in zero-terminated arrays the same as in sized arrays, GLib::Array and GLib::PtrArray.
