### PR TITLE
Restore independence of GObjectIntrospection::Strv implementation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -54,8 +54,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake test:all
+      - name: Run test suites
+        run: bundle exec rake test:suites
       - name: Run features
         run: bundle exec rake test:features
 

--- a/lib/ffi-gobject_introspection/strv.rb
+++ b/lib/ffi-gobject_introspection/strv.rb
@@ -24,7 +24,7 @@ module GObjectIntrospection
       offset = 0
       while (ptr = fetch_ptr offset)
         offset += POINTER_SIZE
-        yield ptr.to_utf8
+        yield ptr.read_string.force_encoding(Encoding::UTF_8)
       end
     end
 


### PR DESCRIPTION
- **Restore independence of GObjectIntrospection::Strv implementation**
- **Run seperated test suite in CI to ensure namespace independence**
