### PR TITLE
When mocking GObject.boxed_free, still actually free the boxed struct

### DIFF
--- a/test/gir_ffi/boxed_base_test.rb
+++ b/test/gir_ffi/boxed_base_test.rb
@@ -43,7 +43,7 @@ describe GirFFI::BoxedBase do
 
   describe "upon garbage collection" do
     it "frees and disowns the underlying struct if it is owned" do
-      allow(GObject).to receive(:boxed_free)
+      allow(GObject).to receive(:boxed_free).and_call_original
       gtype = GIMarshallingTests::BoxedStruct.gtype
 
       owned_struct = GIMarshallingTests::BoxedStruct.new.struct


### PR DESCRIPTION
This prevents intermittent warnings during garbage collection when running the test suite.
