### PR TITLE
Ensure class structs are initialized

### DIFF
--- a/lib/gir_ffi/builders/object_builder.rb
+++ b/lib/gir_ffi/builders/object_builder.rb
@@ -64,6 +64,7 @@ module GirFFI
         setup_layout
         setup_constants
         stub_methods
+        ensure_class_struct_initialized
         setup_property_accessors
         setup_vfunc_invokers
         setup_interfaces
@@ -97,6 +98,13 @@ module GirFFI
 
       def parent_ancestor_infos
         @parent_ancestor_infos ||= parent_builder.ancestor_infos
+      end
+
+      # If the class struct is not initialized, calling some functions may lead
+      # to a segfault (for example, for GIMarshallingTests::Object.vfunc_static_name),
+      # or an incorrect return value (for example, for Regress::TestBoxedC#name_conflict).
+      def ensure_class_struct_initialized
+        klass.class_struct
       end
 
       def setup_property_accessors

--- a/lib/gir_ffi/object_base.rb
+++ b/lib/gir_ffi/object_base.rb
@@ -101,7 +101,7 @@ module GirFFI
 
     def self.install_vfunc_implementation(name, implementation = nil)
       if const_defined? :GIR_FFI_BUILDER, false
-        raise "Installing a property in a class that is already set up is not supported"
+        raise "Installing a vfunc in a class that is already set up is not supported"
       end
 
       prepare_user_defined_class

--- a/test/integration/generated_regress_test.rb
+++ b/test/integration/generated_regress_test.rb
@@ -1899,11 +1899,6 @@ describe Regress do
     end
 
     it "defines callback type Matrix in the metaclass namespace" do
-      # Make sure Regress::TestObjClass exists
-      # NOTE: Perhaps gtype struct classes should be stored out of the way in
-      # some other namespace.
-      Regress::TestObj.class_struct
-
       _(Regress::TestObjClass.const_defined?(:Matrix)).must_equal true
       _(Regress.const_defined?(:Matrix)).must_equal false
     end


### PR DESCRIPTION
Calling functions and methods before the class struct is initialized can lead to segfaults and random results.
